### PR TITLE
Use artifacts output layout and modern CI props

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,87 @@
+# This workflow will build and test the package project
+name: Bonsai.Mixer
+
+on:
+  push:
+  pull_request:
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_GENERATE_ASPNET_CERTIFICATE: false
+  ContinuousIntegrationBuild: true
+  CiRunNumber: ${{ github.run_number }}
+  CiRunPushSuffix: ${{ github.ref_name }}-ci${{ github.run_number }}
+  CiRunPullSuffix: pull-${{ github.event.number }}-ci${{ github.run_number }}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [debug, release]
+        os: [windows-latest]
+        include:
+          - os: windows-latest
+            configuration: release
+            collect-packages: true
+    name: ${{matrix.os}} ${{matrix.configuration}}
+    runs-on: ${{matrix.os}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration ${{ matrix.configuration }}
+
+      - name: Test
+        run: dotnet test --no-build --verbosity normal --configuration ${{ matrix.configuration }}
+
+      - name: Pack
+        id: pack
+        if: matrix.collect-packages
+        env:
+          CiBuildVersionSuffix: ${{ github.event_name == 'push' && env.CiRunPushSuffix || env.CiRunPullSuffix }}
+        run: dotnet pack --no-build --configuration ${{ matrix.configuration }}
+
+      - name: Collect packages
+        uses: actions/upload-artifact@v4
+        if: matrix.collect-packages && steps.pack.outcome == 'success' && always()
+        with:
+          name: Packages
+          if-no-files-found: error
+          path: artifacts/package/${{ matrix.configuration }}/**
+
+  publish-github:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    needs: [build]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.x
+
+      - name: Download packages
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: Packages
+
+      - name: Push to GitHub Packages
+        run: dotnet nuget push "Packages/*.nupkg" --skip-duplicate --no-symbols --api-key ${{secrets.GITHUB_TOKEN}} --source https://nuget.pkg.github.com/${{github.repository_owner}}
+        env:
+          # This is a workaround for https://github.com/NuGet/Home/issues/9775
+          DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER: 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .vs/
 /artifacts/
-/bonsai/Packages/
-*.exe
-*.exe.*
+*.user

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,25 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <Authors>Bonsai</Authors>
-    <Copyright>Copyright © Bonsai Foundation CIC and Contributors 2024</Copyright>
-    <PackageProjectUrl>https://github.com/bonsai-rx/mixer</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/bonsai-rx/mixer.git</RepositoryUrl>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <UseArtifactsOutput>true</UseArtifactsOutput>
-    <PackageIcon>icon.png</PackageIcon>
-    <IncludeSymbols>true</IncludeSymbols>
-    <RepositoryType>git</RepositoryType>
-    <VersionPrefix>0.1.0</VersionPrefix>
-    <LangVersion>10.0</LangVersion>
-    <Features>strict</Features>
-  </PropertyGroup>
-  
-  <Import Project="build/Version.props" />
-
-  <ItemGroup>
-    <Content Include="..\..\LICENSE" PackagePath="/" />
-    <Content Include="..\..\icon.png" PackagePath="/" />
-  </ItemGroup>
+  <Import Project="build/Common.props" />
 </Project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 Bonsai Foundation CIC and Contributors
+Copyright (c) Bonsai Foundation CIC and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bonsai/.gitignore
+++ b/bonsai/.gitignore
@@ -1,0 +1,3 @@
+Bonsai.exe
+Bonsai.exe.*
+Packages/

--- a/build/Bonsai.props
+++ b/build/Bonsai.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- For configuring launchSettings.json we need to resolve the bootstrapper output path here -->
+  <PropertyGroup>
+    <BonsaiExecutablePath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../bonsai/Bonsai.exe'))</BonsaiExecutablePath>
+  </PropertyGroup>
+</Project>

--- a/build/Common.props
+++ b/build/Common.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <LangVersion>latest</LangVersion>
+    <Features>strict</Features>
+  </PropertyGroup>
+
+  <Import Project="Bonsai.props" />
+  <Import Project="Package.props" />
+  <Import Project="Version.props" />
+</Project>

--- a/build/Package.props
+++ b/build/Package.props
@@ -1,0 +1,20 @@
+<Project>
+  <PropertyGroup>
+    <Authors>Bonsai</Authors>
+    <Copyright>Copyright © Bonsai Foundation CIC and Contributors</Copyright>
+    <PackageProjectUrl>https://bonsai-rx.org/mixer</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageType>Dependency;BonsaiLibrary</PackageType>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon.png</PackageIcon>
+    <IncludeSymbols>true</IncludeSymbols>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)..\LICENSE" PackagePath="/" />
+    <Content Include="$(MSBuildThisFileDirectory)..\icon.png" PackagePath="/" />
+    <Content Include="$(MSBuildThisFileDirectory)..\README.md" PackagePath="/" />
+  </ItemGroup>
+</Project>

--- a/build/Version.props
+++ b/build/Version.props
@@ -1,4 +1,9 @@
 <Project>
+  <PropertyGroup>
+    <!-- Semantic version prefix -->
+    <VersionPrefix>0.1.0</VersionPrefix>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' != 'true'">
     <!-- When making local builds DevVersion can be overridden to generate multiple local versions -->
     <DevVersion Condition="'$(DevVersion)' == ''">0</DevVersion>


### PR DESCRIPTION
This PR introduces the github actions workflow to use only dotnet directly, taking advantage of modern CI props and the cleaner artifacts output layout.

Minimal version properties are also included along with new automated CI workflows for test builds and preview package deployment.