### PR TITLE
Allow setting suggested latency in MixerStreamContext

### DIFF
--- a/src/Bonsai.Mixer/CreateMixerContext.cs
+++ b/src/Bonsai.Mixer/CreateMixerContext.cs
@@ -1,8 +1,5 @@
-﻿using Bonsai;
-using System;
+﻿using System;
 using System.ComponentModel;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reactive.Linq;
 using PortAudioNet;
 using System.Reactive.Disposables;
@@ -21,6 +18,8 @@ namespace Bonsai.Mixer
         public string DeviceName { get; set; }
 
         public double SampleRate { get; set; } = 48e3;
+
+        public double? SuggestedLatency { get; set; }
 
         public unsafe IObservable<MixerStreamContext> Generate()
         {
@@ -52,7 +51,7 @@ namespace Bonsai.Mixer
                     }
                 }
 
-                var mixerStream = new MixerStreamContext(selectedIndex, SampleRate);
+                var mixerStream = new MixerStreamContext(selectedIndex, SampleRate, SuggestedLatency);
                 observer.OnNext(mixerStream);
                 return Disposable.Create(() =>
                 {

--- a/src/Bonsai.Mixer/MixerStreamContext.cs
+++ b/src/Bonsai.Mixer/MixerStreamContext.cs
@@ -122,5 +122,12 @@ namespace Bonsai.Mixer
             mixerBuffers.Clear();
             handle.Free();
         }
+
+        public override string ToString()
+        {
+            return $"{nameof(MixerStreamContext)} {{ " +
+                   $"{nameof(SampleRate)} = {SampleRate}, " +
+                   $"{nameof(OutputLatency)} = {OutputLatency} }}";
+        }
     }
 }


### PR DESCRIPTION
Suggested latency parameters are the latencies requested when a stream is first opened. They may range from zero to infinity.

When not specified, the default low output latency for the selected device will be used. The suggested latency can be used to override the default and may be required to lower the latency to the absolute minimum possible. See [Guidelines for implementing PortAudio buffering, latency and timing](https://github.com/PortAudio/portaudio/wiki/BufferingLatencyAndTimingImplementationGuidelines#user-pa_openstream-parameters-that-affect-latency) for a more detailed discussion.

Ultimately, PortAudio will limit the actual latency within implementable bounds, but there is no guarantee these are workable, so testing and benchmarking are always recommended.

`SampleRate` and `OutputLatency` have also been included in the text representation of the `MixerStreamContext` object to make it easier to assess the actual runtime parameters of the stream.

Fixes #7 