### PR TITLE
Avoid stopping the stream when disposing mixer

### DIFF
--- a/src/Bonsai.Mixer/CreateMixerContext.cs
+++ b/src/Bonsai.Mixer/CreateMixerContext.cs
@@ -55,7 +55,6 @@ namespace Bonsai.Mixer
                 observer.OnNext(mixerStream);
                 return Disposable.Create(() =>
                 {
-                    mixerStream.Stop();
                     mixerStream.Dispose();
                     engine.Dispose();
                 });


### PR DESCRIPTION
Closing the stream already stops buffer playback and avoids redundant checks and exceptions.

Fixes #5 