### PR TITLE
Allow requesting a specific channel count

### DIFF
--- a/src/Bonsai.Mixer/CreateMixerContext.cs
+++ b/src/Bonsai.Mixer/CreateMixerContext.cs
@@ -44,6 +44,15 @@ namespace Bonsai.Mixer
         public double SampleRate { get; set; } = 48e3;
 
         /// <summary>
+        /// Gets or sets the number of output channels to open the stream with.
+        /// </summary>
+        /// <remarks>
+        /// If not specified, the maximum number of channels supported by the selected device is used.
+        /// </remarks>
+        [Description("The number of output channels to open the stream with.")]
+        public int? ChannelCount { get; set; }
+
+        /// <summary>
         /// Gets or sets the desired output latency, in seconds.
         /// </summary>
         /// <remarks>
@@ -63,7 +72,7 @@ namespace Bonsai.Mixer
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The output sequence will emit an error if the specified target device or host API
-        /// cannot be found.
+        /// cannot be found, or if the requested number of channels is not supported by the device.
         /// </exception>
         public unsafe IObservable<MixerStreamContext> Generate()
         {
@@ -108,7 +117,7 @@ namespace Bonsai.Mixer
                         throw new InvalidOperationException(
                             $"Device '{targetDeviceName}' could not be found in '{targetHostApi}'.");
 
-                var mixerStream = new MixerStreamContext(selectedIndex, SampleRate, SuggestedLatency);
+                var mixerStream = new MixerStreamContext(selectedIndex, SampleRate, ChannelCount, SuggestedLatency);
                 observer.OnNext(mixerStream);
                 return Disposable.Create(() =>
                 {

--- a/src/Bonsai.Mixer/MixerStreamContext.cs
+++ b/src/Bonsai.Mixer/MixerStreamContext.cs
@@ -17,14 +17,22 @@ namespace Bonsai.Mixer
         private readonly PaStreamParameters streamParameters;
         private readonly WorkQueue<MixerSourceContext> mixerSources;
 
-        internal MixerStreamContext(int deviceIndex, double sampleRate, double? suggestedLatency = null)
+        internal MixerStreamContext(int deviceIndex, double sampleRate, int? channelCount = null, double? suggestedLatency = null)
         {
             handle = GCHandle.Alloc(this);
             selectedDevice = PortAudio.GetDeviceInfo(deviceIndex);
+            var maxOutputChannels = selectedDevice->maxOutputChannels;
+            if (channelCount.HasValue && (channelCount.GetValueOrDefault() < 1 || channelCount.GetValueOrDefault() > maxOutputChannels))
+            {
+                throw new InvalidOperationException(
+                    $"The requested number of channels ({channelCount.GetValueOrDefault()}) is out of range; " +
+                    $"the device supports between 1 and {maxOutputChannels} output channels.");
+            }
+
             PaStreamParameters parameters = new()
             {
                 device = deviceIndex,
-                channelCount = selectedDevice->maxOutputChannels,
+                channelCount = channelCount ?? maxOutputChannels,
                 sampleFormat = PaSampleFormat.Float32,
                 suggestedLatency = suggestedLatency ?? selectedDevice->defaultLowOutputLatency,
                 hostApiSpecificStreamInfo = null,


### PR DESCRIPTION
`CreateMixerContext` always opened the stream with the maximum number of output channels supported by the device. This adds a `ChannelCount` property that allows opening the stream with a requested number of channels, validated against the device maximum. If no channel count is specified, it keeps using the device maximum, so existing workflows are unchanged.

Closes #15