### PR TITLE
Add pause and resume for mixer sources

### DIFF
--- a/src/Bonsai.Mixer/CreateSource.cs
+++ b/src/Bonsai.Mixer/CreateSource.cs
@@ -20,6 +20,12 @@ namespace Bonsai.Mixer
         public bool Loop { get; set; }
 
         /// <summary>
+        /// Gets or sets a value specifying the initial playback state of the source.
+        /// </summary>
+        [Description("The initial playback state of the source.")]
+        public MixerSourceState InitialState { get; set; }
+
+        /// <summary>
         /// Creates a new mixer source on every mixer stream context in an observable sequence.
         /// </summary>
         /// <param name="source">
@@ -33,7 +39,7 @@ namespace Bonsai.Mixer
         {
             return source.SelectMany(mixer => Observable.Create<MixerSourceContext>(observer =>
             {
-                var context = mixer.CreateSource(Loop);
+                var context = mixer.CreateSource(Loop, InitialState);
                 observer.OnNext(context);
                 return Disposable.Create(() => context.Stop(0));
             }));

--- a/src/Bonsai.Mixer/MixerSourceContext.cs
+++ b/src/Bonsai.Mixer/MixerSourceContext.cs
@@ -29,11 +29,13 @@ namespace Bonsai.Mixer
         int bufferIndex;
         int sampleIndex;
         bool stopping;
+        bool paused;
 
-        internal MixerSourceContext(int channelCount, double sampleRate, Mat initialBuffer, bool loop, bool removeOnComplete)
+        internal MixerSourceContext(int channelCount, double sampleRate, Mat initialBuffer, bool loop, bool paused, bool removeOnComplete)
         {
             this.channelCount = channelCount;
             this.loop = loop;
+            this.paused = paused;
             this.removeOnComplete = removeOnComplete;
             gain = new LinearRamp(sampleRate, 1f);
             if (initialBuffer is not null)
@@ -97,6 +99,31 @@ namespace Bonsai.Mixer
         }
 
         /// <summary>
+        /// Resumes playback of the source from its current position.
+        /// </summary>
+        /// <remarks>
+        /// Playback resumes from the buffer and sample where it was paused. Resuming a source
+        /// that is already playing has no effect.
+        /// </remarks>
+        public void Play()
+        {
+            commandQueue.Add(() => paused = false);
+        }
+
+        /// <summary>
+        /// Pauses playback of the source, holding its position until playback is resumed.
+        /// </summary>
+        /// <remarks>
+        /// The playback cursor and queued buffers are retained while paused, and the source
+        /// stops contributing to the output without being removed. Pausing a source that is
+        /// already paused has no effect.
+        /// </remarks>
+        public void Pause()
+        {
+            commandQueue.Add(() => paused = true);
+        }
+
+        /// <summary>
         /// Stops playback of the source, fading the gain to silence over the specified duration
         /// before the source is removed from the mixer.
         /// </summary>
@@ -119,6 +146,9 @@ namespace Bonsai.Mixer
                 command();
                 return true;
             });
+
+            if (paused)
+                return stopping ? PaStreamCallbackResult.Complete : PaStreamCallbackResult.Continue;
 
             int frame = 0;
             while (frame < frameCount)

--- a/src/Bonsai.Mixer/MixerSourceState.cs
+++ b/src/Bonsai.Mixer/MixerSourceState.cs
@@ -1,0 +1,18 @@
+﻿namespace Bonsai.Mixer
+{
+    /// <summary>
+    /// Specifies the playback state of a mixer source.
+    /// </summary>
+    public enum MixerSourceState
+    {
+        /// <summary>
+        /// The source is playing, advancing its playback cursor.
+        /// </summary>
+        Playing,
+
+        /// <summary>
+        /// The source is paused, holding its playback cursor.
+        /// </summary>
+        Paused
+    }
+}

--- a/src/Bonsai.Mixer/MixerStreamContext.cs
+++ b/src/Bonsai.Mixer/MixerStreamContext.cs
@@ -107,7 +107,7 @@ namespace Bonsai.Mixer
         /// </exception>
         public void PlayBuffer(Mat buffer)
         {
-            var source = new MixerSourceContext(streamParameters.channelCount, SampleRate, buffer, loop: false, removeOnComplete: true);
+            var source = new MixerSourceContext(streamParameters.channelCount, SampleRate, buffer, loop: false, paused: false, removeOnComplete: true);
             mixerSources.Add(source);
         }
 
@@ -119,13 +119,17 @@ namespace Bonsai.Mixer
         /// True to loop the playback queue continuously; otherwise playback stops once all queued
         /// buffers have played.
         /// </param>
+        /// <param name="initialState">
+        /// The initial playback state of the source.
+        /// </param>
         /// <returns>
         /// A new <see cref="MixerSourceContext"/> used to queue buffers into the source and
         /// control its playback.
         /// </returns>
-        public MixerSourceContext CreateSource(bool loop)
+        public MixerSourceContext CreateSource(bool loop, MixerSourceState initialState)
         {
-            var source = new MixerSourceContext(streamParameters.channelCount, SampleRate, initialBuffer: null, loop, removeOnComplete: false);
+            var paused = initialState == MixerSourceState.Paused;
+            var source = new MixerSourceContext(streamParameters.channelCount, SampleRate, initialBuffer: null, loop, paused, removeOnComplete: false);
             mixerSources.Add(source);
             return source;
         }

--- a/src/Bonsai.Mixer/PauseSource.cs
+++ b/src/Bonsai.Mixer/PauseSource.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+
+namespace Bonsai.Mixer
+{
+    /// <summary>
+    /// Represents an operator that pauses playback of every mixer source in the sequence,
+    /// holding its position until playback is resumed.
+    /// </summary>
+    [Description("Pauses playback of every mixer source in the sequence, holding its position until playback is resumed.")]
+    public class PauseSource : Sink<MixerSourceContext>
+    {
+        /// <summary>
+        /// Pauses playback of every mixer source in an observable sequence, holding its position
+        /// until playback is resumed.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="MixerSourceContext"/> objects whose playback is paused.
+        /// </param>
+        /// <returns>
+        /// An observable sequence that is identical to the <paramref name="source"/> sequence
+        /// but where there is an additional side effect of pausing playback of every mixer
+        /// source in the sequence.
+        /// </returns>
+        public override IObservable<MixerSourceContext> Process(IObservable<MixerSourceContext> source)
+        {
+            return source.Do(mixerSource => mixerSource.Pause());
+        }
+    }
+}

--- a/src/Bonsai.Mixer/PlaySource.cs
+++ b/src/Bonsai.Mixer/PlaySource.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+
+namespace Bonsai.Mixer
+{
+    /// <summary>
+    /// Represents an operator that resumes playback of every mixer source in the sequence from
+    /// its current position.
+    /// </summary>
+    [Description("Resumes playback of every mixer source in the sequence from its current position.")]
+    public class PlaySource : Sink<MixerSourceContext>
+    {
+        /// <summary>
+        /// Resumes playback of every mixer source in an observable sequence from its current
+        /// position.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="MixerSourceContext"/> objects whose playback is resumed.
+        /// </param>
+        /// <returns>
+        /// An observable sequence that is identical to the <paramref name="source"/> sequence
+        /// but where there is an additional side effect of resuming playback of every mixer
+        /// source in the sequence.
+        /// </returns>
+        public override IObservable<MixerSourceContext> Process(IObservable<MixerSourceContext> source)
+        {
+            return source.Do(mixerSource => mixerSource.Play());
+        }
+    }
+}


### PR DESCRIPTION
Until now the only way to halt a mixer source was `StopSource`, which is terminal: it fades to silence and removes the source. This adds resumable playback control. `PlaySource` and `PauseSource` halt a source in place and resume it, retaining its playback cursor and queued buffers, so a paused source contributes nothing to the output until resumed while other sources keep playing. Keeping pause and resume separate from the terminal `StopSource` is what lets a source be held without being destroyed.

Pause and resume are instantaneous. Stopping a paused source removes it immediately without a fade, since it contributes no signal that a fade would need to taper off.

`CreateSource` gains an `InitialState` property, using a new `MixerSourceState` enum, so a source can be created already paused. This makes the arm-then-trigger pattern race-free: buffers can be appended to a source that has not started, then playback triggered on a precise event with a single `PlaySource`, with no window in which the source could play before being paused.

Closes #20