### PR TITLE
Report playback state for mixer sources

### DIFF
--- a/src/Bonsai.Mixer/CreateSource.cs
+++ b/src/Bonsai.Mixer/CreateSource.cs
@@ -16,14 +16,21 @@ namespace Bonsai.Mixer
         /// <summary>
         /// Gets or sets a value specifying whether the source loops its playback queue continuously.
         /// </summary>
+        /// <remarks>
+        /// True to loop the playback queue continuously; otherwise playback stops once all queued
+        /// buffers have played.
+        /// </remarks>
         [Description("True to loop the playback queue continuously; otherwise playback stops once all queued buffers have played.")]
-        public bool Loop { get; set; }
+        public bool Looping { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying the initial playback state of the source.
+        /// Gets or sets a value specifying whether the source starts playing immediately.
         /// </summary>
-        [Description("The initial playback state of the source.")]
-        public MixerSourceState InitialState { get; set; }
+        /// <remarks>
+        /// True to start the source playing immediately; otherwise the source starts paused.
+        /// </remarks>
+        [Description("True to start the source playing immediately; otherwise the source starts paused.")]
+        public bool Playing { get; set; } = true;
 
         /// <summary>
         /// Creates a new mixer source on every mixer stream context in an observable sequence.
@@ -39,7 +46,7 @@ namespace Bonsai.Mixer
         {
             return source.SelectMany(mixer => Observable.Create<MixerSourceContext>(observer =>
             {
-                var context = mixer.CreateSource(Loop, InitialState);
+                var context = mixer.CreateSource(Looping, Playing);
                 observer.OnNext(context);
                 return Disposable.Create(() => context.Stop(0));
             }));

--- a/src/Bonsai.Mixer/MixerSourceContext.cs
+++ b/src/Bonsai.Mixer/MixerSourceContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reactive.Subjects;
 using OpenCV.Net;
 using PortAudioNet;
 
@@ -19,24 +20,29 @@ namespace Bonsai.Mixer
         const int BlockSize = 256;
 
         readonly int channelCount;
-        readonly bool loop;
+        readonly bool looping;
         readonly bool removeOnComplete;
         readonly List<Mat> buffers = new();
         readonly WorkQueue<Action> commandQueue = new();
         readonly LinearRamp gain;
         readonly float[] gainBlock = new float[BlockSize];
+        readonly BehaviorSubject<MixerSourceState> playbackState;
 
         int bufferIndex;
         int sampleIndex;
         bool stopping;
-        bool paused;
+        bool playing;
+        MixerSourceState currentState;
+        MixerSourceState reportedState;
 
-        internal MixerSourceContext(int channelCount, double sampleRate, Mat initialBuffer, bool loop, bool paused, bool removeOnComplete)
+        internal MixerSourceContext(int channelCount, double sampleRate, Mat initialBuffer, bool looping, bool playing, bool removeOnComplete)
         {
             this.channelCount = channelCount;
-            this.loop = loop;
-            this.paused = paused;
+            this.looping = looping;
+            this.playing = playing;
             this.removeOnComplete = removeOnComplete;
+            currentState = reportedState = playing ? MixerSourceState.Playing : MixerSourceState.Paused;
+            playbackState = new BehaviorSubject<MixerSourceState>(currentState);
             gain = new LinearRamp(sampleRate, 1f);
             if (initialBuffer is not null)
             {
@@ -107,7 +113,7 @@ namespace Bonsai.Mixer
         /// </remarks>
         public void Play()
         {
-            commandQueue.Add(() => paused = false);
+            commandQueue.Add(() => playing = true);
         }
 
         /// <summary>
@@ -120,7 +126,7 @@ namespace Bonsai.Mixer
         /// </remarks>
         public void Pause()
         {
-            commandQueue.Add(() => paused = true);
+            commandQueue.Add(() => playing = false);
         }
 
         /// <summary>
@@ -139,23 +145,65 @@ namespace Bonsai.Mixer
             });
         }
 
-        internal PaStreamCallbackResult StreamCallback(float* output, uint frameCount, in PaStreamCallbackTimeInfo timeInfo, PaStreamCallbackFlags statusFlags)
+        /// <summary>
+        /// Gets an observable sequence that reports the playback state of the source, starting with
+        /// its current state and emitting each transition, then completing when the source is
+        /// removed from the mixer.
+        /// </summary>
+        /// <remarks>
+        /// Notifications are delivered off the audio thread. The sequence is backed by a
+        /// <see cref="BehaviorSubject{T}"/>, so a subscriber that connects late receives the current
+        /// state immediately.
+        /// </remarks>
+        internal IObservable<MixerSourceState> PlaybackState => playbackState;
+
+        internal bool TryGetStateChange(out MixerSourceState newState)
         {
-            commandQueue.RemoveAll(command =>
+            if (currentState != reportedState)
+            {
+                newState = reportedState = currentState;
+                return true;
+            }
+
+            newState = default;
+            return false;
+        }
+
+        internal void NotifyState(MixerSourceState newState)
+        {
+            playbackState.OnNext(newState);
+            if (newState == MixerSourceState.Stopped)
+                playbackState.OnCompleted();
+        }
+
+        internal void DispatchCommands()
+        {
+            commandQueue.DispatchReady(command =>
             {
                 command();
                 return true;
             });
+        }
 
-            if (paused)
-                return stopping ? PaStreamCallbackResult.Complete : PaStreamCallbackResult.Continue;
+        internal PaStreamCallbackResult StreamCallback(float* output, uint frameCount, in PaStreamCallbackTimeInfo timeInfo, PaStreamCallbackFlags statusFlags)
+        {
+            DispatchCommands();
+
+            if (!playing)
+            {
+                if (stopping)
+                    return PaStreamCallbackResult.Complete;
+
+                currentState = MixerSourceState.Paused;
+                return PaStreamCallbackResult.Continue;
+            }
 
             int frame = 0;
             while (frame < frameCount)
             {
                 if (bufferIndex >= buffers.Count)
                 {
-                    if (loop && buffers.Count > 0)
+                    if (looping && buffers.Count > 0)
                     {
                         bufferIndex = 0;
                         sampleIndex = 0;
@@ -193,11 +241,20 @@ namespace Bonsai.Mixer
                 }
             }
 
-            var exhausted = bufferIndex >= buffers.Count && !(loop && buffers.Count > 0);
+            var exhausted = bufferIndex >= buffers.Count && !(looping && buffers.Count > 0);
             if (stopping)
-                return gain.IsCompleted || exhausted ? PaStreamCallbackResult.Complete : PaStreamCallbackResult.Continue;
+            {
+                if (gain.IsCompleted || exhausted)
+                    return PaStreamCallbackResult.Complete;
+
+                currentState = MixerSourceState.Playing;
+                return PaStreamCallbackResult.Continue;
+            }
+
             if (removeOnComplete && buffers.Count > 0 && exhausted)
                 return PaStreamCallbackResult.Complete;
+
+            currentState = exhausted ? MixerSourceState.Idle : MixerSourceState.Playing;
             return PaStreamCallbackResult.Continue;
         }
     }

--- a/src/Bonsai.Mixer/MixerSourceState.cs
+++ b/src/Bonsai.Mixer/MixerSourceState.cs
@@ -13,6 +13,16 @@
         /// <summary>
         /// The source is paused, holding its playback cursor.
         /// </summary>
-        Paused
+        Paused,
+
+        /// <summary>
+        /// The source is playing but has no more samples to play.
+        /// </summary>
+        Idle,
+
+        /// <summary>
+        /// The source has been removed from the mixer.
+        /// </summary>
+        Stopped
     }
 }

--- a/src/Bonsai.Mixer/MixerStreamContext.cs
+++ b/src/Bonsai.Mixer/MixerStreamContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 using OpenCV.Net;
 using PortAudioNet;
 
@@ -16,6 +17,10 @@ namespace Bonsai.Mixer
         private readonly PaDeviceInfo* selectedDevice;
         private readonly PaStreamParameters streamParameters;
         private readonly WorkQueue<MixerSourceContext> mixerSources;
+        private readonly RingBuffer<PlaybackStateEvent> playbackEvents;
+        private readonly AutoResetEvent notificationSignal;
+        private readonly Thread notificationThread;
+        private volatile bool disposed;
 
         internal MixerStreamContext(int deviceIndex, double sampleRate, int? channelCount = null, double? suggestedLatency = null)
         {
@@ -59,6 +64,10 @@ namespace Bonsai.Mixer
             mixerStream = stream;
             streamParameters = parameters;
             mixerSources = new();
+            playbackEvents = new RingBuffer<PlaybackStateEvent>(1024);
+            notificationSignal = new AutoResetEvent(false);
+            notificationThread = new Thread(DeliverNotifications) { IsBackground = true, Name = "MixerNotifications" };
+            notificationThread.Start();
         }
 
         /// <summary>
@@ -107,7 +116,7 @@ namespace Bonsai.Mixer
         /// </exception>
         public void PlayBuffer(Mat buffer)
         {
-            var source = new MixerSourceContext(streamParameters.channelCount, SampleRate, buffer, loop: false, paused: false, removeOnComplete: true);
+            var source = new MixerSourceContext(streamParameters.channelCount, SampleRate, buffer, looping: false, playing: true, removeOnComplete: true);
             mixerSources.Add(source);
         }
 
@@ -115,21 +124,20 @@ namespace Bonsai.Mixer
         /// Creates a new mixer source whose playback queue can be controlled independently of any
         /// other source mixed into the output stream.
         /// </summary>
-        /// <param name="loop">
+        /// <param name="looping">
         /// True to loop the playback queue continuously; otherwise playback stops once all queued
         /// buffers have played.
         /// </param>
-        /// <param name="initialState">
-        /// The initial playback state of the source.
+        /// <param name="playing">
+        /// True to start the source playing immediately; otherwise the source starts paused.
         /// </param>
         /// <returns>
         /// A new <see cref="MixerSourceContext"/> used to queue buffers into the source and
         /// control its playback.
         /// </returns>
-        public MixerSourceContext CreateSource(bool loop, MixerSourceState initialState)
+        public MixerSourceContext CreateSource(bool looping, bool playing)
         {
-            var paused = initialState == MixerSourceState.Paused;
-            var source = new MixerSourceContext(streamParameters.channelCount, SampleRate, initialBuffer: null, loop, paused, removeOnComplete: false);
+            var source = new MixerSourceContext(streamParameters.channelCount, SampleRate, initialBuffer: null, looping, playing, removeOnComplete: false);
             mixerSources.Add(source);
             return source;
         }
@@ -143,6 +151,7 @@ namespace Bonsai.Mixer
         /// </remarks>
         public void Start()
         {
+            mixerSources.DispatchAll(source => { source.DispatchCommands(); return false; });
             PortAudio.StartStream(mixerStream).ThrowIfFailure();
         }
 
@@ -170,13 +179,42 @@ namespace Bonsai.Mixer
                 }
             }
 
-            mixerSources.RemoveAll(source =>
+            var notify = false;
+            mixerSources.DispatchReady(source =>
             {
                 var result = source.StreamCallback(outputBuffer, frameCount, in localTimeInfo, statusFlags);
-                return result != PaStreamCallbackResult.Continue;
+                if (result != PaStreamCallbackResult.Continue)
+                {
+                    playbackEvents.TryEnqueue(new PlaybackStateEvent(source, MixerSourceState.Stopped));
+                    notify = true;
+                    return true;
+                }
+
+                if (source.TryGetStateChange(out var newState))
+                {
+                    playbackEvents.TryEnqueue(new PlaybackStateEvent(source, newState));
+                    notify = true;
+                }
+
+                return false;
             });
 
+            if (notify)
+                notificationSignal.Set();
             return PaStreamCallbackResult.Continue;
+        }
+
+        private void DeliverNotifications()
+        {
+            while (true)
+            {
+                notificationSignal.WaitOne();
+                while (playbackEvents.TryDequeue(out var playbackEvent))
+                    playbackEvent.Source.NotifyState(playbackEvent.State);
+
+                if (disposed)
+                    break;
+            }
         }
 
 #if NET5_0_OR_GREATER
@@ -207,7 +245,15 @@ namespace Bonsai.Mixer
         public void Dispose()
         {
             PortAudio.CloseStream(mixerStream);
-            mixerSources.Clear();
+            disposed = true;
+            notificationSignal.Set();
+            notificationThread.Join();
+            mixerSources.DispatchAll(source =>
+            {
+                source.NotifyState(MixerSourceState.Stopped);
+                return true;
+            });
+            notificationSignal.Dispose();
             handle.Free();
         }
 

--- a/src/Bonsai.Mixer/PlaybackState.cs
+++ b/src/Bonsai.Mixer/PlaybackState.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+
+namespace Bonsai.Mixer
+{
+    /// <summary>
+    /// Represents an operator that reports the playback state of each mixer source in the
+    /// sequence, emitting its current state and every subsequent transition.
+    /// </summary>
+    [Description("Reports the playback state of each mixer source in the sequence, emitting its current state and every subsequent transition.")]
+    public class PlaybackState : Combinator<MixerSourceContext, MixerSourceState>
+    {
+        /// <summary>
+        /// Reports the playback state of each mixer source in an observable sequence, emitting its
+        /// current state and every subsequent transition.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="MixerSourceContext"/> objects whose playback state is reported.
+        /// </param>
+        /// <returns>
+        /// An observable sequence of <see cref="MixerSourceState"/> values, starting with the
+        /// current state of each source and emitting each transition, completing when the source is
+        /// removed from the mixer.
+        /// </returns>
+        public override IObservable<MixerSourceState> Process(IObservable<MixerSourceContext> source)
+        {
+            return source.SelectMany(mixerSource => mixerSource.PlaybackState);
+        }
+    }
+}

--- a/src/Bonsai.Mixer/PlaybackStateEvent.cs
+++ b/src/Bonsai.Mixer/PlaybackStateEvent.cs
@@ -1,0 +1,12 @@
+﻿namespace Bonsai.Mixer
+{
+    /// <summary>
+    /// A source playback-state transition handed from the audio callback thread to the
+    /// notification pump.
+    /// </summary>
+    internal readonly struct PlaybackStateEvent(MixerSourceContext source, MixerSourceState state)
+    {
+        public readonly MixerSourceContext Source = source;
+        public readonly MixerSourceState State = state;
+    }
+}

--- a/src/Bonsai.Mixer/RingBuffer.cs
+++ b/src/Bonsai.Mixer/RingBuffer.cs
@@ -1,0 +1,55 @@
+﻿using System.Threading;
+
+namespace Bonsai.Mixer
+{
+    /// <summary>
+    /// A bounded single-producer, single-consumer ring buffer used to hand notifications off from
+    /// the audio callback thread to the notification pump without locking or allocating.
+    /// </summary>
+    /// <remarks>
+    /// The producer advances the tail and the consumer advances the head, each publishing its
+    /// index after the element access so the other side observes a consistent slot. The capacity
+    /// must be a power of two so the index wrap reduces to a bitmask.
+    /// </remarks>
+    /// <typeparam name="T">The type of the elements stored in the buffer.</typeparam>
+    internal sealed class RingBuffer<T>
+    {
+        readonly T[] items;
+        readonly int mask;
+        int head;
+        int tail;
+
+        public RingBuffer(int capacity)
+        {
+            items = new T[capacity];
+            mask = capacity - 1;
+        }
+
+        public bool TryEnqueue(T item)
+        {
+            var currentTail = tail;
+            var next = (currentTail + 1) & mask;
+            if (next == Volatile.Read(ref head))
+                return false;
+
+            items[currentTail] = item;
+            Volatile.Write(ref tail, next);
+            return true;
+        }
+
+        public bool TryDequeue(out T item)
+        {
+            var currentHead = head;
+            if (currentHead == Volatile.Read(ref tail))
+            {
+                item = default;
+                return false;
+            }
+
+            item = items[currentHead];
+            items[currentHead] = default;
+            Volatile.Write(ref head, (currentHead + 1) & mask);
+            return true;
+        }
+    }
+}

--- a/src/Bonsai.Mixer/WorkQueue.cs
+++ b/src/Bonsai.Mixer/WorkQueue.cs
@@ -12,14 +12,21 @@ namespace Bonsai.Mixer
     /// processed by a single consumer. A double buffering strategy is used to ensure the
     /// consumer remains lock-free. Importantly, the buffer swap happens when the work on
     /// the consumer queue is entirely done.
-    /// 
+    ///
     /// It is possible producers are still in the process of adding an item during the
     /// swap, but there is no critical work done immediately after, so this is acceptable.
     /// Processing of all active work items is done on a different buffer altogether and
     /// the newly swapped out queue will only be accessed at the start of the next cycle.
-    /// 
+    ///
     /// The assumption is that by the time we are done with everything and need the next
     /// items we will be done with processing a single <c>Add</c> call.
+    ///
+    /// <see cref="DispatchReady"/> is the lock-free consumer operation and processes only
+    /// the items already published by a previous swap, so the most recent additions are
+    /// dispatched on the following call. <see cref="DispatchAll"/> takes the lock to also
+    /// process items still in the producer buffer in one pass, and is therefore only safe
+    /// to call while no consumer is running, such as before the stream starts requesting
+    /// data or after it has stopped.
     /// </remarks>
     internal class WorkQueue<T>
     {
@@ -36,7 +43,7 @@ namespace Bonsai.Mixer
             }
         }
 
-        public void RemoveAll(Predicate<T> match)
+        public void DispatchReady(Predicate<T> match)
         {
             var newItems = consumerQueue;
             workItems.AddRange(newItems);
@@ -47,14 +54,17 @@ namespace Bonsai.Mixer
             workItems.RemoveAll(match);
         }
 
-        public void Clear()
+        public void DispatchAll(Predicate<T> match)
         {
             lock (gate)
             {
-                workItems.Clear();
-                producerQueue.Clear();
+                workItems.AddRange(consumerQueue);
+                workItems.AddRange(producerQueue);
                 consumerQueue.Clear();
+                producerQueue.Clear();
             }
+
+            workItems.RemoveAll(match);
         }
     }
 }


### PR DESCRIPTION
Mixer sources can now report their playback state as an observable sequence, so a workflow can observe when a source is playing, paused, out of samples, or removed from the mixer. The new `PlaybackState` operator emits the current state of a source and then every subsequent transition, completing when the source is removed. The sequence is backed by a `BehaviorSubject`, so an observer that connects late still receives the current state immediately.

## Playback states

`MixerSourceState` reports one of four states:

- `Playing`: the source has samples and is advancing its cursor.
- `Paused`: the source is held at its current cursor by `Pause`.
- `Idle`: the source is playing but has run out of samples. Appending more buffers resumes playback automatically.
- `Stopped`: the source has been removed from the mixer. This is emitted once, after which the sequence completes.

`Idle` and `Stopped` are new members added for reporting. A source that has never been appended to reports `Idle` immediately, which is accurate rather than treated as a special case.

## Off-thread delivery

State transitions originate on the PortAudio callback thread, which must stay allocation-free and lock-free. The callback records each transition into a bounded single-producer, single-consumer ring buffer, and a background thread per mixer stream drains the ring buffer and emits on the per-source subject. The audio thread only advances state and writes a value into a ring slot, so it never allocates or blocks. When a mixer stream is disposed, every live source reports `Stopped` and its sequence completes.

## API changes

These are breaking changes to the source API, taken now ahead of the release:

- `CreateSource.Loop` is renamed to `Looping`.
- `CreateSource` replaces its `InitialState` enum property with a `Playing` flag that defaults to true. A source can still start paused by setting `Playing` to false for the arm-then-play pattern.
- `MixerSourceState` is now reporting-only. It no longer configures the initial state, which is what lets it carry the new `Idle` and `Stopped` reporting states.

## Scope

This PR reports playback state at the source level. Notifying when an individual queued buffer finishes playing, as required by #17, is a planned follow-up.