### PR TITLE
Reclaim consumed buffers for non-looping sources

### DIFF
--- a/src/Bonsai.Mixer/MixerSourceContext.cs
+++ b/src/Bonsai.Mixer/MixerSourceContext.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Reactive.Subjects;
 using OpenCV.Net;
 using PortAudioNet;
@@ -22,7 +21,7 @@ namespace Bonsai.Mixer
         readonly int channelCount;
         readonly bool looping;
         readonly bool removeOnComplete;
-        readonly List<Mat> buffers = new();
+        readonly RingList<Mat> buffers = new();
         readonly WorkQueue<Action> commandQueue = new();
         readonly LinearRamp gain;
         readonly float[] gainBlock = new float[BlockSize];
@@ -239,6 +238,12 @@ namespace Bonsai.Mixer
                     bufferIndex++;
                     sampleIndex = 0;
                 }
+            }
+
+            if (!looping && !removeOnComplete && bufferIndex > 0)
+            {
+                buffers.RemoveRange(bufferIndex);
+                bufferIndex = 0;
             }
 
             var exhausted = bufferIndex >= buffers.Count && !(looping && buffers.Count > 0);

--- a/src/Bonsai.Mixer/RingList.cs
+++ b/src/Bonsai.Mixer/RingList.cs
@@ -1,0 +1,43 @@
+﻿namespace Bonsai.Mixer
+{
+    /// <summary>
+    /// A growable first-in first-out collection with indexed access, backed by a circular buffer.
+    /// Single-threaded, unlike the lock-free <see cref="RingBuffer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements stored in the collection.</typeparam>
+    internal sealed class RingList<T>
+    {
+        T[] items = new T[4];
+        int head;
+
+        public int Count { get; private set; }
+
+        public T this[int index] => items[(head + index) % items.Length];
+
+        public void Add(T item)
+        {
+            if (Count == items.Length)
+            {
+                var newItems = new T[items.Length * 2];
+                for (int i = 0; i < Count; i++)
+                    newItems[i] = items[(head + i) % items.Length];
+                items = newItems;
+                head = 0;
+            }
+
+            items[(head + Count) % items.Length] = item;
+            Count++;
+        }
+
+        public void RemoveRange(int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                items[head] = default;
+                head = (head + 1) % items.Length;
+            }
+
+            Count -= count;
+        }
+    }
+}


### PR DESCRIPTION
The per-source playback queue is append-only, and a source previously kept every buffer for its lifetime. A looping source needs that, since it cycles back through the whole queue, but a non-looping source that streams a long or open-ended signal retains buffers behind the playback cursor that will never play again, so its memory grows without bound.

This reclaims played buffers for non-looping sources. Once the cursor has passed a buffer, the source drops it, bounding memory to the un-played tail plus the buffer currently playing.

## Scope

Reclaim applies only to non-looping sources that are not one-shots:

- Looping sources cannot reclaim, since they replay the whole queue on each pass.
- One-shot sources created by `PlayBuffer` are removed whole the moment they finish, so there is nothing to reclaim and their completion path is left untouched.

## Queue representation

The playback queue moves from an append-only `List` to a new `RingList`, a small growable circular buffer. It drops from the front in constant time by advancing a head index and releasing the slot, rather than shifting the remaining entries as a list would, and it keeps indexed access so the looping cursor can still cycle the queue. All access happens on the audio callback thread, so unlike the lock-free `RingBuffer` it needs no synchronization. The head index also preserves a stable absolute position for each buffer, leaving room for future per-buffer addressing without reworking the queue.

Closes #23