### PR TITLE
Add per-channel gain for spatial positioning

### DIFF
--- a/src/Bonsai.Mixer/LinearRamp.cs
+++ b/src/Bonsai.Mixer/LinearRamp.cs
@@ -26,7 +26,7 @@ namespace Bonsai.Mixer
 
         public bool IsCompleted => remainingSamples == 0;
 
-        public void RampTo(float target, double duration)
+        public void SetTarget(float target, double duration)
         {
             this.target = target;
             remainingSamples = (int)Math.Max(0, duration * sampleRate);

--- a/src/Bonsai.Mixer/MixerSourceContext.cs
+++ b/src/Bonsai.Mixer/MixerSourceContext.cs
@@ -10,9 +10,9 @@ namespace Bonsai.Mixer
     /// </summary>
     /// <remarks>
     /// A source maintains an ordered queue of audio buffers played back through a single read
-    /// cursor, scaled by a gain that can vary over time. The source is an opaque handle created
-    /// by the mixer and controlled by downstream operators that append buffers, set the gain,
-    /// or stop playback.
+    /// cursor, scaled by a per-channel gain that can vary over time. The source is an opaque
+    /// handle created by the mixer and controlled by downstream operators that append buffers,
+    /// set the gain, or stop playback.
     /// </remarks>
     public unsafe class MixerSourceContext
     {
@@ -21,10 +21,10 @@ namespace Bonsai.Mixer
         readonly int channelCount;
         readonly bool looping;
         readonly bool removeOnComplete;
-        readonly RingList<Mat> buffers = new();
+        readonly RingList<Mat> sourceBuffers = new();
         readonly WorkQueue<Action> commandQueue = new();
-        readonly LinearRamp gain;
-        readonly float[] gainBlock = new float[BlockSize];
+        readonly LinearRamp[] gainRamps;
+        readonly float[] gainBuffer;
         readonly BehaviorSubject<MixerSourceState> playbackState;
 
         int bufferIndex;
@@ -42,11 +42,14 @@ namespace Bonsai.Mixer
             this.removeOnComplete = removeOnComplete;
             currentState = reportedState = playing ? MixerSourceState.Playing : MixerSourceState.Paused;
             playbackState = new BehaviorSubject<MixerSourceState>(currentState);
-            gain = new LinearRamp(sampleRate, 1f);
+            gainRamps = new LinearRamp[channelCount];
+            for (int i = 0; i < channelCount; i++)
+                gainRamps[i] = new LinearRamp(sampleRate, 1f);
+            gainBuffer = new float[channelCount * BlockSize];
             if (initialBuffer is not null)
             {
                 Validate(initialBuffer);
-                buffers.Add(initialBuffer);
+                sourceBuffers.Add(initialBuffer);
             }
         }
 
@@ -55,9 +58,9 @@ namespace Bonsai.Mixer
             if (buffer is null)
                 throw new ArgumentNullException(nameof(buffer));
 
-            if (buffer.Rows != channelCount)
+            if (buffer.Rows != 1 && buffer.Rows != channelCount)
                 throw new ArgumentException(
-                    "The number of rows in the sample buffer must be the same as the number of channels.",
+                    "The number of rows in the sample buffer must be one, for a mono source, or equal to the number of channels.",
                     nameof(buffer));
 
             if (buffer.Cols < 1)
@@ -76,31 +79,70 @@ namespace Bonsai.Mixer
         /// </summary>
         /// <param name="buffer">
         /// A multi-dimensional array containing the sample data, where each row holds the samples
-        /// for one channel.
+        /// for one channel. A single-row buffer is played as a mono source and distributed across
+        /// the output channels by the per-channel gain.
         /// </param>
         /// <exception cref="ArgumentNullException">The buffer is null.</exception>
         /// <exception cref="ArgumentException">
-        /// The number of rows does not match the number of channels in the stream, the buffer
+        /// The number of rows is neither one nor the number of channels in the stream, the buffer
         /// contains no samples, or the sample depth is not 32-bit floating point.
         /// </exception>
         public void Append(Mat buffer)
         {
             Validate(buffer);
-            commandQueue.Add(() => buffers.Add(buffer));
+            commandQueue.Add(() => sourceBuffers.Add(buffer));
         }
 
         /// <summary>
-        /// Sets the gain of the source to a target level over the specified duration.
+        /// Sets the gain of every output channel of the source to a new level over the specified
+        /// duration.
         /// </summary>
-        /// <param name="target">
-        /// The target gain level, where 1 represents the original signal amplitude.
+        /// <param name="value">
+        /// The gain level, where 1 represents the original signal amplitude.
         /// </param>
         /// <param name="duration">
         /// The length of the gain ramp, in seconds. A duration of zero changes the gain immediately.
         /// </param>
-        public void SetGain(float target, double duration)
+        public void SetGain(float value, double duration)
         {
-            commandQueue.Add(() => gain.RampTo(target, duration));
+            commandQueue.Add(() =>
+            {
+                for (int i = 0; i < gainRamps.Length; i++)
+                    gainRamps[i].SetTarget(value, duration);
+            });
+        }
+
+        /// <summary>
+        /// Sets the gain of each output channel of the source to a separate level over the
+        /// specified duration.
+        /// </summary>
+        /// <param name="values">
+        /// The gain level for each output channel, where 1 represents the original signal
+        /// amplitude. The number of values must be equal to the number of channels.
+        /// </param>
+        /// <param name="duration">
+        /// The length of the gain ramp, in seconds. A duration of zero changes the gain immediately.
+        /// </param>
+        /// <exception cref="ArgumentNullException">The array of values is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// The number of values is not equal to the number of channels.
+        /// </exception>
+        public void SetGain(float[] values, double duration)
+        {
+            if (values is null)
+                throw new ArgumentNullException(nameof(values));
+
+            if (values.Length != channelCount)
+                throw new ArgumentException(
+                    "The number of gain values must be equal to the number of channels.",
+                    nameof(values));
+
+            var channelValues = (float[])values.Clone();
+            commandQueue.Add(() =>
+            {
+                for (int i = 0; i < gainRamps.Length; i++)
+                    gainRamps[i].SetTarget(channelValues[i], duration);
+            });
         }
 
         /// <summary>
@@ -140,7 +182,8 @@ namespace Bonsai.Mixer
             commandQueue.Add(() =>
             {
                 stopping = true;
-                gain.RampTo(0f, fadeDuration);
+                for (int i = 0; i < gainRamps.Length; i++)
+                    gainRamps[i].SetTarget(0f, fadeDuration);
             });
         }
 
@@ -184,6 +227,15 @@ namespace Bonsai.Mixer
             });
         }
 
+        bool IsGainSettled()
+        {
+            for (int i = 0; i < gainRamps.Length; i++)
+                if (!gainRamps[i].IsCompleted)
+                    return false;
+
+            return true;
+        }
+
         internal PaStreamCallbackResult StreamCallback(float* output, uint frameCount, in PaStreamCallbackTimeInfo timeInfo, PaStreamCallbackFlags statusFlags)
         {
             DispatchCommands();
@@ -200,9 +252,9 @@ namespace Bonsai.Mixer
             int frame = 0;
             while (frame < frameCount)
             {
-                if (bufferIndex >= buffers.Count)
+                if (bufferIndex >= sourceBuffers.Count)
                 {
-                    if (looping && buffers.Count > 0)
+                    if (looping && sourceBuffers.Count > 0)
                     {
                         bufferIndex = 0;
                         sampleIndex = 0;
@@ -210,24 +262,26 @@ namespace Bonsai.Mixer
                     else break;
                 }
 
-                var buffer = buffers[bufferIndex];
-                buffer.GetRawData(out IntPtr dataPtr, out int step);
+                var currentBuffer = sourceBuffers[bufferIndex];
+                currentBuffer.GetRawData(out IntPtr dataPtr, out int step);
                 var samples = (float*)dataPtr.ToPointer();
                 var stepSamples = step / sizeof(float);
-                var bufferColumns = buffer.Cols;
+                var bufferRows = currentBuffer.Rows;
+                var bufferColumns = currentBuffer.Cols;
 
                 var available = bufferColumns - sampleIndex;
                 var count = Math.Min(Math.Min(available, (int)frameCount - frame), BlockSize);
-                gain.Generate(gainBlock.AsSpan(0, count));
+                for (int channel = 0; channel < channelCount; channel++)
+                    gainRamps[channel].Generate(gainBuffer.AsSpan(channel * BlockSize, count));
 
                 for (int i = 0; i < count; i++)
                 {
-                    var amplitude = gainBlock[i];
                     var sampleColumn = sampleIndex + i;
                     var outputIndex = (frame + i) * channelCount;
                     for (int channel = 0; channel < channelCount; channel++)
                     {
-                        output[outputIndex + channel] += amplitude * samples[channel * stepSamples + sampleColumn];
+                        var row = bufferRows == 1 ? 0 : channel;
+                        output[outputIndex + channel] += gainBuffer[channel * BlockSize + i] * samples[row * stepSamples + sampleColumn];
                     }
                 }
 
@@ -242,21 +296,21 @@ namespace Bonsai.Mixer
 
             if (!looping && !removeOnComplete && bufferIndex > 0)
             {
-                buffers.RemoveRange(bufferIndex);
+                sourceBuffers.RemoveRange(bufferIndex);
                 bufferIndex = 0;
             }
 
-            var exhausted = bufferIndex >= buffers.Count && !(looping && buffers.Count > 0);
+            var exhausted = bufferIndex >= sourceBuffers.Count && !(looping && sourceBuffers.Count > 0);
             if (stopping)
             {
-                if (gain.IsCompleted || exhausted)
+                if (IsGainSettled() || exhausted)
                     return PaStreamCallbackResult.Complete;
 
                 currentState = MixerSourceState.Playing;
                 return PaStreamCallbackResult.Continue;
             }
 
-            if (removeOnComplete && buffers.Count > 0 && exhausted)
+            if (removeOnComplete && sourceBuffers.Count > 0 && exhausted)
                 return PaStreamCallbackResult.Complete;
 
             currentState = exhausted ? MixerSourceState.Idle : MixerSourceState.Playing;

--- a/src/Bonsai.Mixer/SetChannelGain.cs
+++ b/src/Bonsai.Mixer/SetChannelGain.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+
+namespace Bonsai.Mixer
+{
+    /// <summary>
+    /// Represents an operator that sets the per-channel gain of every mixer source in the sequence
+    /// to a set of target levels over a specified duration.
+    /// </summary>
+    [Description("Sets the per-channel gain of every mixer source in the sequence to a set of target levels over a specified duration.")]
+    public class SetChannelGain : Sink<MixerSourceContext>
+    {
+        /// <summary>
+        /// Gets or sets the target gain level for each output channel, where 1 represents the
+        /// original signal amplitude.
+        /// </summary>
+        [TypeConverter(typeof(UnidimensionalArrayConverter))]
+        [Description("The target gain level for each output channel, where 1 represents the original signal amplitude.")]
+        public double[] Gain { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration of the gain ramp, in seconds.
+        /// </summary>
+        /// <remarks>
+        /// The default of 20 milliseconds keeps the gain change smooth, since very short ramps can
+        /// produce audible clipping. A duration of zero changes the gain immediately.
+        /// </remarks>
+        [Description("The duration of the gain ramp, in seconds. A value of zero changes the gain immediately.")]
+        public double Duration { get; set; } = 0.02;
+
+        /// <summary>
+        /// Sets the per-channel gain of every mixer source in an observable sequence to the target
+        /// levels over the specified duration.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="MixerSourceContext"/> objects whose per-channel gain is set.
+        /// </param>
+        /// <returns>
+        /// An observable sequence that is identical to the <paramref name="source"/> sequence
+        /// but where there is an additional side effect of setting the per-channel gain of every
+        /// mixer source in the sequence.
+        /// </returns>
+        public override IObservable<MixerSourceContext> Process(IObservable<MixerSourceContext> source)
+        {
+            return source.Do(mixerSource =>
+            {
+                var gain = Gain;
+                if (gain is null)
+                    throw new InvalidOperationException("The Gain property must specify a target level for each output channel.");
+
+                var targets = new float[gain.Length];
+                for (int i = 0; i < gain.Length; i++)
+                    targets[i] = (float)gain[i];
+
+                mixerSource.SetGain(targets, Duration);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Per-source gain was a single scalar applied equally to every output channel, so positioning a mono source in space, or moving it across speakers over time, meant building a buffer with one row per channel and distributing the signal by hand, coupling the spatial layout into the source content. This generalizes the gain to a separate level per output channel and lets a source play from a single-row mono buffer, so a mono signal plus a set of channel gains localizes and pans without an N-row buffer.

## Per-channel gain

Each source now holds an independent gain per output channel instead of one scalar. The new `SetChannelGain` operator sets a separate level for each channel, ramped over its `Duration` like `SetGain`, so panning a source is a matter of ramping the channel gains. It takes the levels as a `Gain` vector property with inline entry, so you can type a fixed layout by hand or drive it dynamically through property mapping from something like a spatial lookup.

The existing `SetGain` is unchanged. It now sets every channel to one level, which reproduces the previous output exactly, so existing workflows behave identically.

## Mono buffers

Source buffers may now have either a single row or number of rows equal to full channel count. A single-row buffer is played as a mono source and broadcast across the output channels scaled by the per-channel gain, so spatializing a mono signal no longer requires replicating it into one row per channel upstream. Multichannel buffers are unchanged, with each row scaled by its channel gain.

Closes #22