### PR TITLE
Separate source and per-channel gain layers

### DIFF
--- a/src/Bonsai.Mixer/CreateSource.cs
+++ b/src/Bonsai.Mixer/CreateSource.cs
@@ -33,6 +33,16 @@ namespace Bonsai.Mixer
         public bool Playing { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the initial source gain, where 1 represents the original signal amplitude.
+        /// </summary>
+        /// <remarks>
+        /// The source starts at this gain rather than the default unity, so it can begin silent
+        /// for a clean fade-in, or at a chosen level.
+        /// </remarks>
+        [Description("The initial source gain, where 1 represents the original signal amplitude.")]
+        public float Gain { get; set; } = 1;
+
+        /// <summary>
         /// Creates a new mixer source on every mixer stream context in an observable sequence.
         /// </summary>
         /// <param name="source">
@@ -46,7 +56,7 @@ namespace Bonsai.Mixer
         {
             return source.SelectMany(mixer => Observable.Create<MixerSourceContext>(observer =>
             {
-                var context = mixer.CreateSource(Looping, Playing);
+                var context = mixer.CreateSource(Looping, Playing, Gain);
                 observer.OnNext(context);
                 return Disposable.Create(() => context.Stop(0));
             }));

--- a/src/Bonsai.Mixer/MixerSourceContext.cs
+++ b/src/Bonsai.Mixer/MixerSourceContext.cs
@@ -10,21 +10,19 @@ namespace Bonsai.Mixer
     /// </summary>
     /// <remarks>
     /// A source maintains an ordered queue of audio buffers played back through a single read
-    /// cursor, scaled by a per-channel gain that can vary over time. The source is an opaque
-    /// handle created by the mixer and controlled by downstream operators that append buffers,
-    /// set the gain, or stop playback.
+    /// cursor, scaled by a source gain and an independent per-channel gain, each of which can
+    /// vary over time. The source is an opaque handle created by the mixer and controlled by
+    /// downstream operators that append buffers, set the gain, or stop playback.
     /// </remarks>
     public unsafe class MixerSourceContext
     {
-        const int BlockSize = 256;
-
         readonly int channelCount;
         readonly bool looping;
         readonly bool removeOnComplete;
         readonly RingList<Mat> sourceBuffers = new();
         readonly WorkQueue<Action> commandQueue = new();
-        readonly LinearRamp[] gainRamps;
-        readonly float[] gainBuffer;
+        readonly LinearRamp sourceGain;
+        readonly LinearRamp[] channelGains;
         readonly BehaviorSubject<MixerSourceState> playbackState;
 
         int bufferIndex;
@@ -34,7 +32,7 @@ namespace Bonsai.Mixer
         MixerSourceState currentState;
         MixerSourceState reportedState;
 
-        internal MixerSourceContext(int channelCount, double sampleRate, Mat initialBuffer, bool looping, bool playing, bool removeOnComplete)
+        internal MixerSourceContext(int channelCount, double sampleRate, Mat initialBuffer, bool looping, bool playing, float initialGain, bool removeOnComplete)
         {
             this.channelCount = channelCount;
             this.looping = looping;
@@ -42,10 +40,10 @@ namespace Bonsai.Mixer
             this.removeOnComplete = removeOnComplete;
             currentState = reportedState = playing ? MixerSourceState.Playing : MixerSourceState.Paused;
             playbackState = new BehaviorSubject<MixerSourceState>(currentState);
-            gainRamps = new LinearRamp[channelCount];
+            sourceGain = new LinearRamp(sampleRate, initialGain);
+            channelGains = new LinearRamp[channelCount];
             for (int i = 0; i < channelCount; i++)
-                gainRamps[i] = new LinearRamp(sampleRate, 1f);
-            gainBuffer = new float[channelCount * BlockSize];
+                channelGains[i] = new LinearRamp(sampleRate, 1f);
             if (initialBuffer is not null)
             {
                 Validate(initialBuffer);
@@ -94,9 +92,13 @@ namespace Bonsai.Mixer
         }
 
         /// <summary>
-        /// Sets the gain of every output channel of the source to a new level over the specified
-        /// duration.
+        /// Sets the source gain to a new level over the specified duration.
         /// </summary>
+        /// <remarks>
+        /// The source gain scales every output channel uniformly and is independent of the
+        /// per-channel gain. The effective gain applied to a channel is the product of the source
+        /// gain and the per-channel gain for that channel.
+        /// </remarks>
         /// <param name="value">
         /// The gain level, where 1 represents the original signal amplitude.
         /// </param>
@@ -105,17 +107,17 @@ namespace Bonsai.Mixer
         /// </param>
         public void SetGain(float value, double duration)
         {
-            commandQueue.Add(() =>
-            {
-                for (int i = 0; i < gainRamps.Length; i++)
-                    gainRamps[i].SetTarget(value, duration);
-            });
+            commandQueue.Add(() => sourceGain.SetTarget(value, duration));
         }
 
         /// <summary>
-        /// Sets the gain of each output channel of the source to a separate level over the
-        /// specified duration.
+        /// Sets the per-channel gain of the source to a separate level for each output channel over
+        /// the specified duration.
         /// </summary>
+        /// <remarks>
+        /// The per-channel gain is independent of the source gain. The effective gain applied to a
+        /// channel is the product of the source gain and the per-channel gain for that channel.
+        /// </remarks>
         /// <param name="values">
         /// The gain level for each output channel, where 1 represents the original signal
         /// amplitude. The number of values must be equal to the number of channels.
@@ -127,7 +129,7 @@ namespace Bonsai.Mixer
         /// <exception cref="ArgumentException">
         /// The number of values is not equal to the number of channels.
         /// </exception>
-        public void SetGain(float[] values, double duration)
+        public void SetChannelGain(float[] values, double duration)
         {
             if (values is null)
                 throw new ArgumentNullException(nameof(values));
@@ -137,11 +139,10 @@ namespace Bonsai.Mixer
                     "The number of gain values must be equal to the number of channels.",
                     nameof(values));
 
-            var channelValues = (float[])values.Clone();
             commandQueue.Add(() =>
             {
-                for (int i = 0; i < gainRamps.Length; i++)
-                    gainRamps[i].SetTarget(channelValues[i], duration);
+                for (int i = 0; i < channelGains.Length; i++)
+                    channelGains[i].SetTarget(values[i], duration);
             });
         }
 
@@ -182,8 +183,7 @@ namespace Bonsai.Mixer
             commandQueue.Add(() =>
             {
                 stopping = true;
-                for (int i = 0; i < gainRamps.Length; i++)
-                    gainRamps[i].SetTarget(0f, fadeDuration);
+                sourceGain.SetTarget(0f, fadeDuration);
             });
         }
 
@@ -227,16 +227,7 @@ namespace Bonsai.Mixer
             });
         }
 
-        bool IsGainSettled()
-        {
-            for (int i = 0; i < gainRamps.Length; i++)
-                if (!gainRamps[i].IsCompleted)
-                    return false;
-
-            return true;
-        }
-
-        internal PaStreamCallbackResult StreamCallback(float* output, uint frameCount, in PaStreamCallbackTimeInfo timeInfo, PaStreamCallbackFlags statusFlags)
+        internal PaStreamCallbackResult StreamCallback(float** output, uint frameCount, in RenderContext render, in PaStreamCallbackTimeInfo timeInfo, PaStreamCallbackFlags statusFlags)
         {
             DispatchCommands();
 
@@ -250,6 +241,8 @@ namespace Bonsai.Mixer
             }
 
             int frame = 0;
+            float* sourceGainBuffer = render.SourceGainBuffer;
+            float* channelGainBuffer = render.ChannelGainBuffer;
             while (frame < frameCount)
             {
                 if (bufferIndex >= sourceBuffers.Count)
@@ -270,19 +263,19 @@ namespace Bonsai.Mixer
                 var bufferColumns = currentBuffer.Cols;
 
                 var available = bufferColumns - sampleIndex;
-                var count = Math.Min(Math.Min(available, (int)frameCount - frame), BlockSize);
-                for (int channel = 0; channel < channelCount; channel++)
-                    gainRamps[channel].Generate(gainBuffer.AsSpan(channel * BlockSize, count));
+                var count = Math.Min(Math.Min(available, (int)frameCount - frame), RenderContext.BlockSize);
+                sourceGain.Generate(new Span<float>(sourceGainBuffer, count));
 
-                for (int i = 0; i < count; i++)
+                for (int channel = 0; channel < channelCount; channel++)
                 {
-                    var sampleColumn = sampleIndex + i;
-                    var outputIndex = (frame + i) * channelCount;
-                    for (int channel = 0; channel < channelCount; channel++)
-                    {
-                        var row = bufferRows == 1 ? 0 : channel;
-                        output[outputIndex + channel] += gainBuffer[channel * BlockSize + i] * samples[row * stepSamples + sampleColumn];
-                    }
+                    var channelGain = channelGainBuffer + channel * RenderContext.BlockSize;
+                    channelGains[channel].Generate(new Span<float>(channelGain, count));
+
+                    var row = bufferRows == 1 ? 0 : channel;
+                    float* source = samples + row * stepSamples + sampleIndex;
+                    float* destination = output[channel] + frame;
+                    for (int i = 0; i < count; i++)
+                        destination[i] += sourceGainBuffer[i] * channelGain[i] * source[i];
                 }
 
                 sampleIndex += count;
@@ -303,7 +296,7 @@ namespace Bonsai.Mixer
             var exhausted = bufferIndex >= sourceBuffers.Count && !(looping && sourceBuffers.Count > 0);
             if (stopping)
             {
-                if (IsGainSettled() || exhausted)
+                if (sourceGain.IsCompleted || exhausted)
                     return PaStreamCallbackResult.Complete;
 
                 currentState = MixerSourceState.Playing;

--- a/src/Bonsai.Mixer/MixerStreamContext.cs
+++ b/src/Bonsai.Mixer/MixerStreamContext.cs
@@ -16,6 +16,9 @@ namespace Bonsai.Mixer
         private readonly PaStream* mixerStream;
         private readonly PaDeviceInfo* selectedDevice;
         private readonly PaStreamParameters streamParameters;
+        private readonly Mat sourceGainBuffer;
+        private readonly Mat channelGainBuffer;
+        private readonly RenderContext renderContext;
         private readonly WorkQueue<MixerSourceContext> mixerSources;
         private readonly RingBuffer<PlaybackStateEvent> playbackEvents;
         private readonly AutoResetEvent notificationSignal;
@@ -38,7 +41,7 @@ namespace Bonsai.Mixer
             {
                 device = deviceIndex,
                 channelCount = channelCount ?? maxOutputChannels,
-                sampleFormat = PaSampleFormat.Float32,
+                sampleFormat = PaSampleFormat.Float32 | PaSampleFormat.NonInterleaved,
                 suggestedLatency = suggestedLatency ?? selectedDevice->defaultLowOutputLatency,
                 hostApiSpecificStreamInfo = null,
             };
@@ -63,6 +66,14 @@ namespace Bonsai.Mixer
 
             mixerStream = stream;
             streamParameters = parameters;
+            sourceGainBuffer = new Mat(1, RenderContext.BlockSize, Depth.F32, 1);
+            channelGainBuffer = new Mat(parameters.channelCount, RenderContext.BlockSize, Depth.F32, 1);
+            sourceGainBuffer.GetRawData(out IntPtr sourceGainData, out _);
+            channelGainBuffer.GetRawData(out IntPtr channelGainData, out int channelGainStep);
+            if (channelGainStep != RenderContext.BlockSize * sizeof(float))
+                throw new InvalidOperationException(
+                    "The channel gain buffer must be allocated as a continuous matrix for the per-channel stride to be valid.");
+            renderContext = new RenderContext((float*)sourceGainData.ToPointer(), (float*)channelGainData.ToPointer());
             mixerSources = new();
             playbackEvents = new RingBuffer<PlaybackStateEvent>(1024);
             notificationSignal = new AutoResetEvent(false);
@@ -116,7 +127,7 @@ namespace Bonsai.Mixer
         /// </exception>
         public void PlayBuffer(Mat buffer)
         {
-            var source = new MixerSourceContext(streamParameters.channelCount, SampleRate, buffer, looping: false, playing: true, removeOnComplete: true);
+            var source = new MixerSourceContext(streamParameters.channelCount, SampleRate, buffer, looping: false, playing: true, initialGain: 1f, removeOnComplete: true);
             mixerSources.Add(source);
         }
 
@@ -131,13 +142,16 @@ namespace Bonsai.Mixer
         /// <param name="playing">
         /// True to start the source playing immediately; otherwise the source starts paused.
         /// </param>
+        /// <param name="initialGain">
+        /// The initial source gain, where 1 represents the original signal amplitude.
+        /// </param>
         /// <returns>
         /// A new <see cref="MixerSourceContext"/> used to queue buffers into the source and
         /// control its playback.
         /// </returns>
-        public MixerSourceContext CreateSource(bool looping, bool playing)
+        public MixerSourceContext CreateSource(bool looping, bool playing, float initialGain = 1)
         {
-            var source = new MixerSourceContext(streamParameters.channelCount, SampleRate, initialBuffer: null, looping, playing, removeOnComplete: false);
+            var source = new MixerSourceContext(streamParameters.channelCount, SampleRate, initialBuffer: null, looping, playing, initialGain, removeOnComplete: false);
             mixerSources.Add(source);
             return source;
         }
@@ -168,21 +182,20 @@ namespace Bonsai.Mixer
 
         private PaStreamCallbackResult _StreamCallback(void* input, void* output, uint frameCount, in PaStreamCallbackTimeInfo timeInfo, PaStreamCallbackFlags statusFlags)
         {
-            float* outputBuffer = (float*)output;
+            float** outputChannels = (float**)output;
             PaStreamCallbackTimeInfo localTimeInfo = timeInfo;
 
-            for (int i = 0; i < frameCount; i++)
+            for (int channelIndex = 0; channelIndex < streamParameters.channelCount; channelIndex++)
             {
-                for (int channelIndex = 0; channelIndex < streamParameters.channelCount; channelIndex++)
-                {
-                    outputBuffer[i * streamParameters.channelCount + channelIndex] = 0;
-                }
+                var channelBuffer = outputChannels[channelIndex];
+                for (int i = 0; i < frameCount; i++)
+                    channelBuffer[i] = 0;
             }
 
             var notify = false;
             mixerSources.DispatchReady(source =>
             {
-                var result = source.StreamCallback(outputBuffer, frameCount, in localTimeInfo, statusFlags);
+                var result = source.StreamCallback(outputChannels, frameCount, in renderContext, in localTimeInfo, statusFlags);
                 if (result != PaStreamCallbackResult.Continue)
                 {
                     playbackEvents.TryEnqueue(new PlaybackStateEvent(source, MixerSourceState.Stopped));
@@ -254,6 +267,8 @@ namespace Bonsai.Mixer
                 return true;
             });
             notificationSignal.Dispose();
+            sourceGainBuffer.Dispose();
+            channelGainBuffer.Dispose();
             handle.Free();
         }
 

--- a/src/Bonsai.Mixer/RenderContext.cs
+++ b/src/Bonsai.Mixer/RenderContext.cs
@@ -1,0 +1,9 @@
+﻿namespace Bonsai.Mixer
+{
+    internal readonly unsafe struct RenderContext(float* sourceGainBuffer, float* channelGainBuffer)
+    {
+        public const int BlockSize = 256;
+        public readonly float* SourceGainBuffer = sourceGainBuffer;
+        public readonly float* ChannelGainBuffer = channelGainBuffer;
+    }
+}

--- a/src/Bonsai.Mixer/SetChannelGain.cs
+++ b/src/Bonsai.Mixer/SetChannelGain.cs
@@ -8,6 +8,11 @@ namespace Bonsai.Mixer
     /// Represents an operator that sets the per-channel gain of every mixer source in the sequence
     /// to a set of target levels over a specified duration.
     /// </summary>
+    /// <remarks>
+    /// The per-channel gain is independent of the source gain set by <see cref="SetGain"/>. The
+    /// effective gain applied to a channel is the product of the source gain and the per-channel
+    /// gain for that channel, so setting the source gain does not overwrite the per-channel levels.
+    /// </remarks>
     [Description("Sets the per-channel gain of every mixer source in the sequence to a set of target levels over a specified duration.")]
     public class SetChannelGain : Sink<MixerSourceContext>
     {
@@ -17,7 +22,7 @@ namespace Bonsai.Mixer
         /// </summary>
         [TypeConverter(typeof(UnidimensionalArrayConverter))]
         [Description("The target gain level for each output channel, where 1 represents the original signal amplitude.")]
-        public double[] Gain { get; set; }
+        public float[] Gain { get; set; }
 
         /// <summary>
         /// Gets or sets the duration of the gain ramp, in seconds.
@@ -49,11 +54,7 @@ namespace Bonsai.Mixer
                 if (gain is null)
                     throw new InvalidOperationException("The Gain property must specify a target level for each output channel.");
 
-                var targets = new float[gain.Length];
-                for (int i = 0; i < gain.Length; i++)
-                    targets[i] = (float)gain[i];
-
-                mixerSource.SetGain(targets, Duration);
+                mixerSource.SetChannelGain(gain, Duration);
             });
         }
     }

--- a/src/Bonsai.Mixer/SetGain.cs
+++ b/src/Bonsai.Mixer/SetGain.cs
@@ -5,17 +5,22 @@ using System.Reactive.Linq;
 namespace Bonsai.Mixer
 {
     /// <summary>
-    /// Represents an operator that sets the gain of every mixer source in the sequence to a
+    /// Represents an operator that sets the source gain of every mixer source in the sequence to a
     /// target level over a specified duration.
     /// </summary>
-    [Description("Sets the gain of every mixer source in the sequence to a target level over a specified duration.")]
+    /// <remarks>
+    /// The source gain scales every output channel uniformly and is independent of the per-channel
+    /// gain set by <see cref="SetChannelGain"/>. The effective gain applied to a channel is the
+    /// product of the source gain and the per-channel gain for that channel.
+    /// </remarks>
+    [Description("Sets the source gain of every mixer source in the sequence to a target level over a specified duration.")]
     public class SetGain : Sink<MixerSourceContext>
     {
         /// <summary>
-        /// Gets or sets the target gain level, where 1 represents the original signal amplitude.
+        /// Gets or sets the target source gain level, where 1 represents the original signal amplitude.
         /// </summary>
-        [Description("The target gain level, where 1 represents the original signal amplitude.")]
-        public double Gain { get; set; } = 1;
+        [Description("The target source gain level, where 1 represents the original signal amplitude.")]
+        public float Gain { get; set; } = 1;
 
         /// <summary>
         /// Gets or sets the duration of the gain ramp, in seconds.
@@ -28,20 +33,20 @@ namespace Bonsai.Mixer
         public double Duration { get; set; } = 0.02;
 
         /// <summary>
-        /// Sets the gain of every mixer source in an observable sequence to the target level over
-        /// the specified duration.
+        /// Sets the source gain of every mixer source in an observable sequence to the target level
+        /// over the specified duration.
         /// </summary>
         /// <param name="source">
         /// A sequence of <see cref="MixerSourceContext"/> objects whose gain is set.
         /// </param>
         /// <returns>
         /// An observable sequence that is identical to the <paramref name="source"/> sequence
-        /// but where there is an additional side effect of setting the gain of every mixer source
-        /// in the sequence.
+        /// but where there is an additional side effect of setting the source gain of every mixer
+        /// source in the sequence.
         /// </returns>
         public override IObservable<MixerSourceContext> Process(IObservable<MixerSourceContext> source)
         {
-            return source.Do(mixerSource => mixerSource.SetGain((float)Gain, Duration));
+            return source.Do(mixerSource => mixerSource.SetGain(Gain, Duration));
         }
     }
 }


### PR DESCRIPTION
Mixer source gain becomes two independent layers whose product is applied to each output channel, a scalar source gain and the existing per-channel gain. `SetGain` now sets only the source gain and `SetChannelGain` only the per-channel gain.

Previously these shared a single per-channel gain vector that both operators wrote to, so `SetGain` would overwrite any balance set by `SetChannelGain` and vice versa. The two now compose, so setting the source gain no longer resets a per-channel position, and `StopSource` fades the source gain while the per-channel balance holds.

`CreateSource` also takes an initial source gain, so a source can be created at a chosen level or silent for a later fade-in, and the gain properties on `SetGain`, `SetChannelGain`, and `CreateSource` are now `float` to match the internal sample representation.

### Rendering

The output stream is opened non-interleaved, so each source mixes into contiguous per-channel buffers rather than writing strided into an interleaved buffer. The per-callback gain buffers are allocated once by the mixer as continuous matrices and passed to each source through a small `RenderContext`, keeping the audio callback allocation-free.

Closes #30