### PR TITLE
Rename MixerStreamContext to MixerContext

### DIFF
--- a/src/Bonsai.Mixer/CreateMixerContext.cs
+++ b/src/Bonsai.Mixer/CreateMixerContext.cs
@@ -7,10 +7,10 @@ using System.Reactive.Disposables;
 namespace Bonsai.Mixer
 {
     /// <summary>
-    /// Represents an operator that creates a new mixer stream context used to control
+    /// Represents an operator that creates a new mixer context used to control
     /// simultaneous playback of multiple audio buffers.
     /// </summary>
-    [Description("Creates a new mixer stream context used to control simultaneous playback of multiple audio buffers.")]
+    [Description("Creates a new mixer context used to control simultaneous playback of multiple audio buffers.")]
     [Combinator(MethodName = nameof(Generate))]
     [WorkflowElementCategory(ElementCategory.Source)]
     public class CreateMixerContext
@@ -64,19 +64,19 @@ namespace Bonsai.Mixer
         public double? SuggestedLatency { get; set; }
 
         /// <summary>
-        /// Generates an observable sequence that initializes and returns a new mixer stream context
+        /// Generates an observable sequence that initializes and returns a new mixer context
         /// object which can be used to control simultaneous playback of multiple audio buffers.
         /// </summary>
         /// <returns>
-        /// A sequence containing the <see cref="MixerStreamContext"/> object.
+        /// A sequence containing the <see cref="MixerContext"/> object.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The output sequence will emit an error if the specified target device or host API
         /// cannot be found, or if the requested number of channels is not supported by the device.
         /// </exception>
-        public unsafe IObservable<MixerStreamContext> Generate()
+        public unsafe IObservable<MixerContext> Generate()
         {
-            return Observable.Create<MixerStreamContext>(observer =>
+            return Observable.Create<MixerContext>(observer =>
             {
                 var targetHostApi = HostApi;
                 var targetDeviceName = DeviceName;
@@ -117,7 +117,7 @@ namespace Bonsai.Mixer
                         throw new InvalidOperationException(
                             $"Device '{targetDeviceName}' could not be found in '{targetHostApi}'.");
 
-                var mixerStream = new MixerStreamContext(selectedIndex, SampleRate, ChannelCount, SuggestedLatency);
+                var mixerStream = new MixerContext(selectedIndex, SampleRate, ChannelCount, SuggestedLatency);
                 observer.OnNext(mixerStream);
                 return Disposable.Create(() =>
                 {

--- a/src/Bonsai.Mixer/CreateSource.cs
+++ b/src/Bonsai.Mixer/CreateSource.cs
@@ -6,11 +6,11 @@ using System.Reactive.Linq;
 namespace Bonsai.Mixer
 {
     /// <summary>
-    /// Represents an operator that creates a new mixer source on every mixer stream context in
+    /// Represents an operator that creates a new mixer source on every mixer context in
     /// the sequence.
     /// </summary>
     [Combinator]
-    [Description("Creates a new mixer source on every mixer stream context in the sequence.")]
+    [Description("Creates a new mixer source on every mixer context in the sequence.")]
     public class CreateSource
     {
         /// <summary>
@@ -43,16 +43,16 @@ namespace Bonsai.Mixer
         public float Gain { get; set; } = 1;
 
         /// <summary>
-        /// Creates a new mixer source on every mixer stream context in an observable sequence.
+        /// Creates a new mixer source on every mixer context in an observable sequence.
         /// </summary>
         /// <param name="source">
-        /// A sequence of <see cref="MixerStreamContext"/> objects on which to create the audio source.
+        /// A sequence of <see cref="MixerContext"/> objects on which to create the audio source.
         /// </param>
         /// <returns>
         /// An observable sequence of <see cref="MixerSourceContext"/> objects, one created on each
-        /// mixer stream context in the <paramref name="source"/> sequence, used to control playback.
+        /// mixer context in the <paramref name="source"/> sequence, used to control playback.
         /// </returns>
-        public IObservable<MixerSourceContext> Process(IObservable<MixerStreamContext> source)
+        public IObservable<MixerSourceContext> Process(IObservable<MixerContext> source)
         {
             return source.SelectMany(mixer => Observable.Create<MixerSourceContext>(observer =>
             {

--- a/src/Bonsai.Mixer/MixerContext.cs
+++ b/src/Bonsai.Mixer/MixerContext.cs
@@ -10,7 +10,7 @@ namespace Bonsai.Mixer
     /// Represents an audio mixer which allows asynchronous queueing of multiple buffers
     /// for simultaneous playback over a single PortAudio output stream.
     /// </summary>
-    public unsafe class MixerStreamContext : IDisposable
+    public unsafe class MixerContext : IDisposable
     {
         private GCHandle handle;
         private readonly PaStream* mixerStream;
@@ -25,7 +25,7 @@ namespace Bonsai.Mixer
         private readonly Thread notificationThread;
         private volatile bool disposed;
 
-        internal MixerStreamContext(int deviceIndex, double sampleRate, int? channelCount = null, double? suggestedLatency = null)
+        internal MixerContext(int deviceIndex, double sampleRate, int? channelCount = null, double? suggestedLatency = null)
         {
             handle = GCHandle.Alloc(this);
             selectedDevice = PortAudio.GetDeviceInfo(deviceIndex);
@@ -113,7 +113,7 @@ namespace Bonsai.Mixer
         /// Plays an audio buffer as a one-shot source that is removed once it finishes playing.
         /// </summary>
         /// <remarks>
-        /// At any one moment when the mixer stream context is playing, the data streamed to PortAudio
+        /// At any one moment when the mixer context is playing, the data streamed to PortAudio
         /// is the sum of all sources being played.
         /// </remarks>
         /// <param name="buffer">
@@ -236,7 +236,7 @@ namespace Bonsai.Mixer
         private static PaStreamCallbackResult _StreamCallback(void* input, void* output, uint frameCount, PaStreamCallbackTimeInfo* timeInfo, PaStreamCallbackFlags statusFlags, void* userData)
         {
             GCHandle handle = GCHandle.FromIntPtr((IntPtr)userData);
-            MixerStreamContext generator = ((MixerStreamContext)handle.Target!);
+            MixerContext generator = ((MixerContext)handle.Target!);
             return generator._StreamCallback(input, output, frameCount, in *timeInfo, statusFlags);
         }
 
@@ -275,7 +275,7 @@ namespace Bonsai.Mixer
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"{nameof(MixerStreamContext)} {{ " +
+            return $"{nameof(MixerContext)} {{ " +
                    $"{nameof(SampleRate)} = {SampleRate}, " +
                    $"{nameof(OutputLatency)} = {OutputLatency}, " +
                    $"{nameof(ChannelCount)} = {ChannelCount} }}";

--- a/src/Bonsai.Mixer/MixerSourceContext.cs
+++ b/src/Bonsai.Mixer/MixerSourceContext.cs
@@ -6,7 +6,7 @@ using PortAudioNet;
 namespace Bonsai.Mixer
 {
     /// <summary>
-    /// Represents a single audio source playing as one voice over a mixer stream context.
+    /// Represents a single audio source playing as one voice over a mixer context.
     /// </summary>
     /// <remarks>
     /// A source maintains an ordered queue of audio buffers played back through a single read

--- a/src/Bonsai.Mixer/PlayBuffer.cs
+++ b/src/Bonsai.Mixer/PlayBuffer.cs
@@ -7,28 +7,28 @@ namespace Bonsai.Mixer
 {
     /// <summary>
     /// Represents an operator that plays each audio buffer from the first sequence as a one-shot
-    /// source on every mixer stream context in the second sequence.
+    /// source on every mixer context in the second sequence.
     /// </summary>
     [Combinator]
-    [Description("Plays each audio buffer from the first sequence as a one-shot source on every mixer stream context in the second sequence.")]
+    [Description("Plays each audio buffer from the first sequence as a one-shot source on every mixer context in the second sequence.")]
     public class PlayBuffer
     {
         /// <summary>
         /// Plays each audio buffer in an observable sequence as a one-shot source on every mixer
-        /// stream context in a second sequence.
+        /// context in a second sequence.
         /// </summary>
         /// <param name="source">
         /// A sequence of <see cref="Mat"/> objects representing the audio buffers to play.
         /// </param>
         /// <param name="mixer">
-        /// A sequence of <see cref="MixerStreamContext"/> objects on which to play the audio buffers.
+        /// A sequence of <see cref="MixerContext"/> objects on which to play the audio buffers.
         /// </param>
         /// <returns>
         /// An observable sequence that is identical to the <paramref name="source"/> sequence
         /// but where there is an additional side effect of playing each audio buffer as a one-shot
-        /// source on every mixer stream context in the <paramref name="mixer"/> sequence.
+        /// source on every mixer context in the <paramref name="mixer"/> sequence.
         /// </returns>
-        public IObservable<Mat> Process(IObservable<Mat> source, IObservable<MixerStreamContext> mixer)
+        public IObservable<Mat> Process(IObservable<Mat> source, IObservable<MixerContext> mixer)
         {
             return mixer.SelectMany(context => source.Do(context.PlayBuffer));
         }

--- a/src/Bonsai.Mixer/StartMixer.cs
+++ b/src/Bonsai.Mixer/StartMixer.cs
@@ -5,24 +5,24 @@ using System.Reactive.Linq;
 namespace Bonsai.Mixer
 {
     /// <summary>
-    /// Represents an operator that initiates audio processing on every mixer stream
-    /// context in the sequence.
+    /// Represents an operator that initiates audio processing on every mixer context
+    /// in the sequence.
     /// </summary>
-    [Description("Initiates audio processing on every mixer stream context in the sequence.")]
-    public class StartMixer : Sink<MixerStreamContext>
+    [Description("Initiates audio processing on every mixer context in the sequence.")]
+    public class StartMixer : Sink<MixerContext>
     {
         /// <summary>
-        /// Initiates audio processing on every mixer stream context in an observable sequence.
+        /// Initiates audio processing on every mixer context in an observable sequence.
         /// </summary>
         /// <param name="source">
-        /// A sequence of <see cref="MixerStreamContext"/> objects.
+        /// A sequence of <see cref="MixerContext"/> objects.
         /// </param>
         /// <returns>
         /// An observable sequence that is identical to the <paramref name="source"/>
         /// sequence but where there is an additional side effect of initiating
-        /// audio processing on every mixer stream context in the sequence.
+        /// audio processing on every mixer context in the sequence.
         /// </returns>
-        public override IObservable<MixerStreamContext> Process(IObservable<MixerStreamContext> source)
+        public override IObservable<MixerContext> Process(IObservable<MixerContext> source)
         {
             return source.Do(mixer => mixer.Start());
         }

--- a/src/Bonsai.Mixer/StopMixer.cs
+++ b/src/Bonsai.Mixer/StopMixer.cs
@@ -5,24 +5,24 @@ using System.Reactive.Linq;
 namespace Bonsai.Mixer
 {
     /// <summary>
-    /// Represents an operator that stops audio processing on every mixer stream
-    /// context in the sequence.
+    /// Represents an operator that stops audio processing on every mixer context
+    /// in the sequence.
     /// </summary>
-    [Description("Stops audio processing on every mixer stream context in the sequence.")]
-    public class StopMixer : Sink<MixerStreamContext>
+    [Description("Stops audio processing on every mixer context in the sequence.")]
+    public class StopMixer : Sink<MixerContext>
     {
         /// <summary>
-        /// Stops audio processing on every mixer stream context in an observable sequence.
+        /// Stops audio processing on every mixer context in an observable sequence.
         /// </summary>
         /// <param name="source">
-        /// A sequence of <see cref="MixerStreamContext"/> objects.
+        /// A sequence of <see cref="MixerContext"/> objects.
         /// </param>
         /// <returns>
         /// An observable sequence that is identical to the <paramref name="source"/>
         /// sequence but where there is an additional side effect of stopping
-        /// audio processing on every mixer stream context in the sequence.
+        /// audio processing on every mixer context in the sequence.
         /// </returns>
-        public override IObservable<MixerStreamContext> Process(IObservable<MixerStreamContext> source)
+        public override IObservable<MixerContext> Process(IObservable<MixerContext> source)
         {
             return source.Do(mixer => mixer.Stop());
         }


### PR DESCRIPTION
Rename the public `MixerStreamContext` type to `MixerContext`. The operator that creates it is already `CreateMixerContext`, so the type now matches its creator, and it reads consistently alongside `MixerSourceContext`. The "Stream" in the old name was reminiscent of the underlying PortAudio output stream, which is the incidental backend rather than the abstraction the API exposes, whereas `MixerContext` names the durable concept.

The operator names are unchanged. `CreateMixerContext`, `StartMixer`, `StopMixer`, `PlayBuffer`, and `CreateSource` keep their names and now return or take `MixerContext`.