### PR TITLE
Add documentation articles and workflow examples

### DIFF
--- a/.bonsai/Bonsai.config
+++ b/.bonsai/Bonsai.config
@@ -8,6 +8,8 @@
     <Package id="Bonsai.Dsp" version="2.9.0" />
     <Package id="Bonsai.Dsp.Design" version="2.9.0" />
     <Package id="Bonsai.Editor" version="2.9.0" />
+    <Package id="Bonsai.Scripting.Expressions" version="2.10.0" />
+    <Package id="Bonsai.Scripting.Expressions.Design" version="2.10.0" />
     <Package id="Bonsai.System" version="2.9.0" />
     <Package id="DockPanelSuite" version="3.1.1" />
     <Package id="DockPanelSuite.ThemeVS2015" version="3.1.1" />
@@ -21,6 +23,7 @@
     <Package id="Rx-PlatformServices" version="2.2.5" />
     <Package id="SvgNet" version="3.5.0" />
     <Package id="System.Buffers" version="4.6.0" />
+    <Package id="System.Linq.Dynamic.Core" version="1.7.1" />
     <Package id="System.Memory" version="4.6.0" />
     <Package id="System.Numerics.Vectors" version="4.6.0" />
     <Package id="System.Resources.Extensions" version="8.0.0" />
@@ -36,6 +39,8 @@
     <AssemblyReference assemblyName="Bonsai.Dsp" />
     <AssemblyReference assemblyName="Bonsai.Dsp.Design" />
     <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
+    <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
     <AssemblyReference assemblyName="Bonsai.System" />
   </AssemblyReferences>
   <AssemblyLocations>
@@ -46,6 +51,8 @@
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.2.9.0/lib/net472/Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Dsp.Design.2.9.0/lib/net472/Bonsai.Dsp.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages/Bonsai.Editor.2.9.0/lib/net472/Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.2.10.0/lib/net472/Bonsai.Scripting.Expressions.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages/Bonsai.Scripting.Expressions.Design.2.10.0/lib/net472/Bonsai.Scripting.Expressions.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages/Bonsai.System.2.9.0/lib/net472/Bonsai.System.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages/Markdig.0.41.1/lib/net462/Markdig.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages/Microsoft.Web.WebView2.1.0.2792.45/lib/net462/Microsoft.Web.WebView2.Core.dll" />
@@ -55,6 +62,7 @@
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages/jacobslusser.ScintillaNET.3.6.3/lib/net40/ScintillaNET.dll" />
     <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages/SvgNet.3.5.0/lib/net462/SVG.dll" />
     <AssemblyLocation assemblyName="System.Buffers" processorArchitecture="MSIL" location="Packages/System.Buffers.4.6.0/lib/net462/System.Buffers.dll" />
+    <AssemblyLocation assemblyName="System.Linq.Dynamic.Core" processorArchitecture="MSIL" location="Packages/System.Linq.Dynamic.Core.1.7.1/lib/net46/System.Linq.Dynamic.Core.dll" />
     <AssemblyLocation assemblyName="System.Memory" processorArchitecture="MSIL" location="Packages/System.Memory.4.6.0/lib/net462/System.Memory.dll" />
     <AssemblyLocation assemblyName="System.Numerics.Vectors" processorArchitecture="MSIL" location="Packages/System.Numerics.Vectors.4.6.0/lib/net462/System.Numerics.Vectors.dll" />
     <AssemblyLocation assemblyName="System.Reactive.Core" processorArchitecture="MSIL" location="Packages/Rx-Core.2.2.5/lib/net45/System.Reactive.Core.dll" />

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Bonsai.Mixer
+
+`Bonsai.Mixer` provides operators for low-latency, multi-channel audio playback over [PortAudio](https://www.portaudio.com/) in the [Bonsai visual reactive programming language](https://bonsai-rx.org). Play one-shot sounds or controllable looping and streaming sources, with per-channel gain for volume and spatial positioning.
+
+## How to Use
+
+To use `Bonsai.Mixer` for visual reactive programming, install this package using the [Bonsai package manager](https://bonsai-rx.org/docs/articles/packages.html).
+
+## Additional Documentation
+
+For additional documentation and examples, refer to the [official Bonsai.Mixer documentation](https://bonsai-rx.org/mixer).
+
+## Feedback & Contributing
+
+`Bonsai.Mixer` is released as open source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/bonsai-rx/mixer).
+
+Development of this package was supported by funding from the Coen Lab at University College London.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,0 @@
-# Bonsai - Mixer Library
-
-`Bonsai.Mixer` provides operators for low-latency multi-channel audio playback with [PortAudio](https://www.portaudio.com/).
-
-## Acknowledgments
-
-Development of this package was supported by funding from the Coen Lab at University College London.

--- a/docs/articles/audio-model.md
+++ b/docs/articles/audio-model.md
@@ -1,0 +1,27 @@
+---
+uid: audio-model
+---
+
+# How the mixer works
+
+The mixer is built around a real-time audio callback that PortAudio calls whenever the output device needs more samples. Understanding what that callback does, and what it deliberately does not do, explains the latency and why playback stays responsive.
+
+## The audio callback
+
+On each call, the callback fills the output with the sum of the active sources, each scaled by its gain. That is all it does: it runs no synthesis, loads no files, and allocates no buffers. The audio at the output is whatever was produced upstream and appended to the sources.
+
+The callback does not clamp the summed result, so overlapping loud sources or a gain above 1 can push the output past the -1 to 1 range and distort.
+
+## Latency
+
+The mixer context reports the stream `OutputLatency`, the best estimate of the delay between a sample entering the mixer and leaving the device. A lower figure can be requested through the `SuggestedLatency` property when the context is created, but a request the device cannot meet may produce glitches, and some drivers ignore it and pick a latency they can sustain instead, so measuring on the target hardware is more reliable than assuming a value.
+
+## Off the audio callback
+
+Because the callback must return before the device runs short of samples, all the work of producing audio happens elsewhere. Buffers are generated or loaded with the `Bonsai.Dsp` operators in the workflow. The control operators follow the same discipline. Appending a buffer, setting the gain, starting, pausing, or stopping playback all queue a command that the source applies at the start of its next callback, rather than changing shared state directly from the workflow thread.
+
+## Observing playback state
+
+The same discipline applies in the other direction, to the state the mixer reports. Playback-state changes are collected on the audio thread but delivered from a separate background thread, so subscribing to [`PlaybackState`] to log or visualize what a source is doing never blocks the callback, and the audio and observation paths stay independent.
+
+[`PlaybackState`]: xref:Bonsai.Mixer.PlaybackState

--- a/docs/articles/gain-control.md
+++ b/docs/articles/gain-control.md
@@ -1,0 +1,38 @@
+---
+uid: gain-control
+---
+
+# Gain control
+
+Every source has two independent gains that scale its samples on the way into the mixer. The source gain sets the overall level of the source, and the per-channel gain sets a separate level for each output channel. The gain applied to a channel is the product of the two, so the source gain controls how loud the source is while the per-channel gain controls where it appears to be across the speakers, and each can change without disturbing the other.
+
+## Source gain
+
+[`SetGain`] sets the source gain, which scales every output channel by the same amount. The gain is a linear multiplier on the samples rather than a level in decibels, so a `Gain` of 1 keeps the original amplitude, a value between 0 and 1 attenuates, and a value above 1 amplifies.
+
+The change is not instantaneous. The `Duration` property sets how long the gain takes to reach the new level, 20 milliseconds by default, so it changes smoothly rather than jumping, which would produce an audible click. A duration of zero changes the gain immediately. If a new target is set before the previous one finishes, the gain continues from its current level instead of restarting.
+
+A source can also start at a chosen level. [`CreateSource`] has a `Gain` property that sets the initial source gain, so a source can begin silent and fade in, or begin at a set level, avoiding a step from full amplitude when the first [`SetGain`] applies. In the workflow below, the source starts silent, then its gain rises steadily and drops sharply each cycle, and the 20 ms smoothing keeps even the sudden drop free of clicks.
+
+:::workflow
+![Modulating the gain](~/workflows/gain-modulation.bonsai)
+:::
+
+## Per-channel gain
+
+[`SetChannelGain`] sets a separate level for each output channel from an array of values, one per channel. It applies on top of the source gain rather than replacing it, so changing the overall level with [`SetGain`] leaves the per-channel balance in place. On a source that already carries one signal per channel, this balances the channels against each other.
+
+> [!WARNING]
+> The length of the per-channel gain array must equal the mixer context `ChannelCount`.
+
+On a single-row buffer, the signal is broadcast to every output channel, so the per-channel levels alone determine where the sound appears to be across the speakers. [`SetChannelGain`] has the same `Duration` property as [`SetGain`], so moving a source between the speakers is smooth rather than stepped.
+
+For example, on a two-channel stream, a gain of `[1, 0]` places a mono source fully on the left, `[0, 1]` fully on the right, and equal levels put it in the center. Setting different levels on each channel this way is also called panning. The workflow below starts a mono source centered, then moves it fully left and then fully right.
+
+:::workflow
+![Positioning across channels](~/workflows/gain-per-channel.bonsai)
+:::
+
+[`SetGain`]: xref:Bonsai.Mixer.SetGain
+[`SetChannelGain`]: xref:Bonsai.Mixer.SetChannelGain
+[`CreateSource`]: xref:Bonsai.Mixer.CreateSource

--- a/docs/articles/playback-control.md
+++ b/docs/articles/playback-control.md
@@ -1,0 +1,42 @@
+---
+uid: playback-control
+---
+
+# Playback control
+
+Once a source handle is available, three operators control its playback, and one reports what state it is in. Each control operator queues its command onto the source, so the change takes effect on the next audio callback rather than instantly on the workflow thread.
+
+## Playing, pausing, and stopping
+
+- [`PlaySource`] resumes a paused source from its current position. Resuming a source that is already playing has no effect.
+- [`PauseSource`] holds the source at its current position, keeping the queued buffers, and stops it contributing to the output until it resumes.
+- [`StopSource`] fades the source to silence and then removes it from the mixer. The `FadeDuration` property, 20 milliseconds by default, keeps the stop smooth, since a hard cut can produce an audible click. A duration of zero stops playback immediately.
+
+The difference between pausing and stopping is lifetime. A paused source stays on the mixer and can resume. Stopping removes the source permanently, so playing the same sound again requires creating a new source.
+
+The workflow below plays a looping source, pauses it after two seconds, and resumes it two seconds later.
+
+:::workflow
+![Pausing and resuming a source](~/workflows/playback-control-pause-resume.bonsai)
+:::
+
+## Playback states
+
+[`PlaybackState`] reports the state of each source, emitting its current value on subscription and on every subsequent transition, and completing when the source is removed. The state is a [`MixerSourceState`]:
+
+- `Playing`: the source is moving through its queued buffers.
+- `Paused`: the source is holding its position without contributing to the output.
+- `Idle`: the source is still playing but out of samples. A non-looping source reaches this state once its queue empties, and goes back to `Playing` if more buffers are appended.
+- `Stopped`: the source has been removed from the mixer. This is the final state, and it completes the sequence.
+
+State changes are reported off the audio thread, so observing or logging them does not affect audio timing. See [how the mixer works](xref:audio-model).
+
+## Starting a source on a cue
+
+Creating a source with `Playing` set to false, appending its buffer, and starting it with [`PlaySource`] on an external cue prepares the sound in advance. The cue-to-audio delay is then just the output latency rather than the cost of building the buffer. This is the arm-then-trigger pattern.
+
+[`PlaySource`]: xref:Bonsai.Mixer.PlaySource
+[`PauseSource`]: xref:Bonsai.Mixer.PauseSource
+[`StopSource`]: xref:Bonsai.Mixer.StopSource
+[`PlaybackState`]: xref:Bonsai.Mixer.PlaybackState
+[`MixerSourceState`]: xref:Bonsai.Mixer.MixerSourceState

--- a/docs/articles/sources.md
+++ b/docs/articles/sources.md
@@ -1,0 +1,47 @@
+---
+uid: sources
+---
+
+# Audio sources
+
+A source is a controllable voice on the mixer. Where [`PlayBuffer`] plays a buffer once and forgets it, a source persists after it is created, so more audio can be appended to it, its gain changed, and its playback paused, resumed, or stopped while it plays. Every source mixes into the output stream alongside the others until it stops.
+
+## Creating a source
+
+[`CreateSource`] emits a source handle for each mixer context it receives. Connect it downstream of the mixer and store the handle in a `BehaviorSubject`, so it can be shared with the source operators, which queue their commands onto the source to be applied on the audio thread.
+
+- The `Looping` property replays the playback queue continuously. Left unset, the source plays its queued buffers once.
+- The `Playing` property starts the source immediately. Set it to false to create the source paused and start it later with [`PlaySource`], which is the arm-then-trigger pattern covered in [playback control](xref:playback-control).
+
+## Appending buffers
+
+[`AppendBuffer`] appends the audio buffers from its first sequence to the playback queue of every source in its second sequence. The buffers play in the order they arrive, picking up after whatever is already queued.
+
+How the queue plays out then depends on whether the source loops:
+
+- **A fixed looping sound.** Append one or more buffers to a looping source and it cycles through them continuously, so a recorded loop or a synthesized tone plays without a break.
+- **A streaming source.** Append buffers to a non-looping source over time and it plays each one as it arrives, then goes idle when its queue empties. Buffers that have already played are reclaimed, so a long stream does not accumulate memory.
+
+The workflow below shows the looping case, appending a generated tone to a looping source that plays without a break.
+
+:::workflow
+![Looping a source](~/workflows/sources-looping.bonsai)
+:::
+
+## Buffer format
+
+An audio buffer is a [`Mat`] of 32-bit floating-point samples normalized to the range -1 to 1, where 1 is full-scale amplitude. Its columns run along time, and the row count decides how the buffer maps to the output channels:
+
+- **A single row** is a mono buffer. The mixer broadcasts it across every output channel, scaled by the per-channel gain, so one row can be positioned anywhere across the speakers. See [Gain control](xref:gain-control) for more details.
+- **One row per output channel** carries a separate signal for each speaker, matching the `ChannelCount` reported by the mixer context.
+
+Any other row count is rejected, as is a buffer with no samples or a sample depth other than 32-bit floating point.
+
+> [!TIP]
+> Derive the sample rate from the mixer context rather than hardcoding it, so a generated buffer always matches the open stream.
+
+[`CreateSource`]: xref:Bonsai.Mixer.CreateSource
+[`AppendBuffer`]: xref:Bonsai.Mixer.AppendBuffer
+[`PlayBuffer`]: xref:Bonsai.Mixer.PlayBuffer
+[`PlaySource`]: xref:Bonsai.Mixer.PlaySource
+[`Mat`]: xref:OpenCV.Net.Mat

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -1,0 +1,5 @@
+- href: ../index.md
+- href: sources.md
+- href: playback-control.md
+- href: gain-control.md
+- href: audio-model.md

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -78,6 +78,7 @@
     },
     "xref": [
       "https://bonsai-rx.org/docs/xrefmap.yml",
+      "https://horizongir.github.io/opencv.net/xrefmap.yml",
       "https://horizongir.github.io/reactive/xrefmap.yml"
     ]
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,46 @@
----
-_layout: landing
----
+# Getting started
 
-[!INCLUDE [](README.md)]
+`Bonsai.Mixer` provides low-latency, multi-channel audio playback over [PortAudio](https://www.portaudio.com/). It plays audio as one-shot sounds or as long-lived sources that can loop, pause, stop, and move across the speakers while they play. This guide covers how the package fits together and walks through playing a sound.
+
+## Overview
+
+The package is organized around three core concepts:
+
+- **The mixer context** is an output stream on a device. [`CreateMixerContext`] opens it and [`StartMixer`] starts its real-time audio callback. The device, sample rate, channel count, and latency are chosen at creation, and the stream reports the actual values it opened with.
+- **Audio buffers** are the audio content, held as [`Mat`] arrays of 32-bit floating-point samples with one row per output channel, or a single row for a mono sound that the mixer broadcasts across the channels. They are generated or loaded with the usual `Bonsai.Dsp` operators, off the audio thread.
+- **Sources** are the addressable voices that play buffers. [`CreateSource`] emits a handle for appending buffers with [`AppendBuffer`], setting the gain with [`SetGain`], and looping, pausing, or stopping playback.
+
+[`PlayBuffer`] skips the handle entirely, playing a buffer directly on the mixer as a one-shot source managed internally.
+
+The real-time audio callback only sums the active sources and applies gain, leaving all synthesis and processing to the upstream workflow. See [how the mixer works](xref:audio-model) for what this means for latency and logging.
+
+## Playing a sound
+
+Below is a small workflow to open a mixer, start it, and play a single buffer.
+
+:::workflow
+![Playing a buffer](~/workflows/getting-started.bonsai)
+:::
+
+- [`CreateMixerContext`] opens the output stream. Left at its defaults it uses the default device and its maximum channel count.
+- [`StartMixer`] begins requesting audio from the device.
+- Publishing the started context in a `BehaviorSubject` named `Mixer` lets every downstream branch reach the same stream.
+- A `Bonsai.Dsp` generator produces a buffer of `F32` samples, which [`PlayBuffer`] plays once on the mixer.
+
+> [!TIP]
+> Derive the sample rate from the mixer context rather than hardcoding it. Map `SampleRate` from the context onto the generator with a `MemberSelector` and a `PropertyMapping` so the generated buffer always matches the open stream.
+
+## Where to go next
+
+- [Audio sources](xref:sources): create controllable sources, loop them, and append buffers over time.
+- [Playback control](xref:playback-control): play, pause, and stop sources, and observe their state.
+- [Gain control](xref:gain-control): set volume and position a source across the output channels.
+- [How the mixer works](xref:audio-model): the audio callback model, buffer format, and what to keep off the audio thread.
+
+[`CreateMixerContext`]: xref:Bonsai.Mixer.CreateMixerContext
+[`StartMixer`]: xref:Bonsai.Mixer.StartMixer
+[`PlayBuffer`]: xref:Bonsai.Mixer.PlayBuffer
+[`CreateSource`]: xref:Bonsai.Mixer.CreateSource
+[`AppendBuffer`]: xref:Bonsai.Mixer.AppendBuffer
+[`SetGain`]: xref:Bonsai.Mixer.SetGain
+[`Mat`]: xref:OpenCV.Net.Mat

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,2 +1,4 @@
+- name: Documentation
+  href: articles/
 - name: API
   href: ../artifacts/docs/api/

--- a/docs/workflows/gain-modulation.bonsai
+++ b/docs/workflows/gain-modulation.bonsai
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:p1="clr-namespace:Bonsai.Mixer;assembly=Bonsai.Mixer"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:dsp="clr-namespace:Bonsai.Dsp;assembly=Bonsai.Dsp"
+                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:CreateMixerContext">
+          <p1:HostApi />
+          <p1:DeviceName />
+          <p1:SampleRate>48000</p1:SampleRate>
+          <p1:ChannelCount xsi:nil="true" />
+          <p1:SuggestedLatency xsi:nil="true" />
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:StartMixer" />
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:CreateSource">
+          <p1:Looping>true</p1:Looping>
+          <p1:Playing>true</p1:Playing>
+          <p1:Gain>0</p1:Gain>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>Source</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>SampleRate</Selector>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="SampleRate" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="dsp:FunctionGenerator">
+          <dsp:BufferLength>48000</dsp:BufferLength>
+          <dsp:Frequency>440</dsp:Frequency>
+          <dsp:Waveform>Sine</dsp:Waveform>
+          <dsp:SampleRate>48000</dsp:SampleRate>
+          <dsp:Depth>F32</dsp:Depth>
+          <dsp:Amplitude>1</dsp:Amplitude>
+          <dsp:Offset>0</dsp:Offset>
+          <dsp:Phase>0</dsp:Phase>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Source</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:AppendBuffer" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Timer">
+          <rx:DueTime>PT0S</rx:DueTime>
+          <rx:Period>PT0.05S</rx:Period>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="scr:ExpressionTransform">
+        <scr:Expression>it * 0.1 % 1</scr:Expression>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Source</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:WithLatestFrom" />
+      </Expression>
+      <Expression xsi:type="InputMapping">
+        <PropertyMappings>
+          <Property Name="Gain" Selector="Item1" />
+        </PropertyMappings>
+        <Selector>Item2</Selector>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:SetGain">
+          <p1:Gain>1</p1:Gain>
+          <p1:Duration>0.02</p1:Duration>
+        </Combinator>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="12" Label="Source1" />
+      <Edge From="11" To="12" Label="Source2" />
+      <Edge From="13" To="14" Label="Source1" />
+      <Edge From="14" To="16" Label="Source1" />
+      <Edge From="15" To="16" Label="Source2" />
+      <Edge From="16" To="17" Label="Source1" />
+      <Edge From="17" To="18" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/docs/workflows/gain-per-channel.bonsai
+++ b/docs/workflows/gain-per-channel.bonsai
@@ -1,0 +1,121 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:p1="clr-namespace:Bonsai.Mixer;assembly=Bonsai.Mixer"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:dsp="clr-namespace:Bonsai.Dsp;assembly=Bonsai.Dsp"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:CreateMixerContext">
+          <p1:HostApi />
+          <p1:DeviceName />
+          <p1:SampleRate>48000</p1:SampleRate>
+          <p1:ChannelCount>2</p1:ChannelCount>
+          <p1:SuggestedLatency xsi:nil="true" />
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:StartMixer" />
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:CreateSource">
+          <p1:Looping>true</p1:Looping>
+          <p1:Playing>true</p1:Playing>
+          <p1:Gain>1</p1:Gain>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>Source</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>SampleRate</Selector>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="SampleRate" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="dsp:FunctionGenerator">
+          <dsp:BufferLength>48000</dsp:BufferLength>
+          <dsp:Frequency>440</dsp:Frequency>
+          <dsp:Waveform>Sine</dsp:Waveform>
+          <dsp:SampleRate>48000</dsp:SampleRate>
+          <dsp:Depth>F32</dsp:Depth>
+          <dsp:Amplitude>1</dsp:Amplitude>
+          <dsp:Offset>0</dsp:Offset>
+          <dsp:Phase>0</dsp:Phase>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Source</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:AppendBuffer" />
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Source</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Delay">
+          <rx:DueTime>PT2S</rx:DueTime>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:SetChannelGain">
+          <p1:Gain>
+            <p1:float>1</p1:float>
+            <p1:float>0</p1:float>
+          </p1:Gain>
+          <p1:Duration>0.5</p1:Duration>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Delay">
+          <rx:DueTime>PT2S</rx:DueTime>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:SetChannelGain">
+          <p1:Gain>
+            <p1:float>0</p1:float>
+            <p1:float>1</p1:float>
+          </p1:Gain>
+          <p1:Duration>0.5</p1:Duration>
+        </Combinator>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="12" Label="Source1" />
+      <Edge From="11" To="12" Label="Source2" />
+      <Edge From="13" To="14" Label="Source1" />
+      <Edge From="14" To="15" Label="Source1" />
+      <Edge From="15" To="16" Label="Source1" />
+      <Edge From="16" To="17" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/docs/workflows/getting-started.bonsai
+++ b/docs/workflows/getting-started.bonsai
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:p1="clr-namespace:Bonsai.Mixer;assembly=Bonsai.Mixer"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:dsp="clr-namespace:Bonsai.Dsp;assembly=Bonsai.Dsp"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:CreateMixerContext">
+          <p1:HostApi />
+          <p1:DeviceName />
+          <p1:SampleRate>48000</p1:SampleRate>
+          <p1:ChannelCount xsi:nil="true" />
+          <p1:SuggestedLatency xsi:nil="true" />
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:StartMixer" />
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>SampleRate</Selector>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="SampleRate" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="dsp:FunctionGenerator">
+          <dsp:BufferLength>48000</dsp:BufferLength>
+          <dsp:Frequency>440</dsp:Frequency>
+          <dsp:Waveform>Sine</dsp:Waveform>
+          <dsp:SampleRate>48000</dsp:SampleRate>
+          <dsp:Depth>F32</dsp:Depth>
+          <dsp:Amplitude>1</dsp:Amplitude>
+          <dsp:Offset>0</dsp:Offset>
+          <dsp:Phase>0</dsp:Phase>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:PlayBuffer" />
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="9" Label="Source1" />
+      <Edge From="8" To="9" Label="Source2" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/docs/workflows/playback-control-pause-resume.bonsai
+++ b/docs/workflows/playback-control-pause-resume.bonsai
@@ -1,0 +1,108 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:p1="clr-namespace:Bonsai.Mixer;assembly=Bonsai.Mixer"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:dsp="clr-namespace:Bonsai.Dsp;assembly=Bonsai.Dsp"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:CreateMixerContext">
+          <p1:HostApi />
+          <p1:DeviceName />
+          <p1:SampleRate>48000</p1:SampleRate>
+          <p1:ChannelCount xsi:nil="true" />
+          <p1:SuggestedLatency xsi:nil="true" />
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:StartMixer" />
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:CreateSource">
+          <p1:Looping>true</p1:Looping>
+          <p1:Playing>true</p1:Playing>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>Source</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>SampleRate</Selector>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="SampleRate" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="dsp:FunctionGenerator">
+          <dsp:BufferLength>48000</dsp:BufferLength>
+          <dsp:Frequency>440</dsp:Frequency>
+          <dsp:Waveform>Sine</dsp:Waveform>
+          <dsp:SampleRate>48000</dsp:SampleRate>
+          <dsp:Depth>F32</dsp:Depth>
+          <dsp:Amplitude>1</dsp:Amplitude>
+          <dsp:Offset>0</dsp:Offset>
+          <dsp:Phase>0</dsp:Phase>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Source</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:AppendBuffer" />
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Source</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Delay">
+          <rx:DueTime>PT2S</rx:DueTime>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:PauseSource" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Delay">
+          <rx:DueTime>PT2S</rx:DueTime>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:PlaySource" />
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="12" Label="Source1" />
+      <Edge From="11" To="12" Label="Source2" />
+      <Edge From="13" To="14" Label="Source1" />
+      <Edge From="14" To="15" Label="Source1" />
+      <Edge From="15" To="16" Label="Source1" />
+      <Edge From="16" To="17" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/docs/workflows/sources-looping.bonsai
+++ b/docs/workflows/sources-looping.bonsai
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:p1="clr-namespace:Bonsai.Mixer;assembly=Bonsai.Mixer"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:dsp="clr-namespace:Bonsai.Dsp;assembly=Bonsai.Dsp"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:CreateMixerContext">
+          <p1:HostApi />
+          <p1:DeviceName />
+          <p1:SampleRate>48000</p1:SampleRate>
+          <p1:ChannelCount xsi:nil="true" />
+          <p1:SuggestedLatency xsi:nil="true" />
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:StartMixer" />
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:CreateSource">
+          <p1:Looping>true</p1:Looping>
+          <p1:Playing>true</p1:Playing>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>Source</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Mixer</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>SampleRate</Selector>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="SampleRate" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="dsp:FunctionGenerator">
+          <dsp:BufferLength>48000</dsp:BufferLength>
+          <dsp:Frequency>440</dsp:Frequency>
+          <dsp:Waveform>Sine</dsp:Waveform>
+          <dsp:SampleRate>48000</dsp:SampleRate>
+          <dsp:Depth>F32</dsp:Depth>
+          <dsp:Amplitude>1</dsp:Amplitude>
+          <dsp:Offset>0</dsp:Offset>
+          <dsp:Phase>0</dsp:Phase>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Source</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:AppendBuffer" />
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="12" Label="Source1" />
+      <Edge From="11" To="12" Label="Source2" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/Bonsai.Mixer/Bonsai.Mixer.csproj
+++ b/src/Bonsai.Mixer/Bonsai.Mixer.csproj
@@ -5,7 +5,7 @@
     <Description>Bonsai Library containing modules for multi-channel audio capture and playback.</Description>
 
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds a DocFX documentation site for `Bonsai.Mixer`, with a landing page that walks through opening a mixer and playing a sound, four topic articles, and runnable workflow examples embedded in the pages.

The articles are:

- Audio sources: creating controllable sources, looping them, and appending buffers over time.
- Playback control: playing, pausing, and stopping sources, and observing their state.
- Gain control: the source gain and per-channel gain, and how they compose to set a source's level and its position across the speakers.
- How the mixer works: the real-time callback model, the buffer format, and what to keep off the audio thread.

Each article embeds one or more `.bonsai` workflows that render as diagrams in the built site and open directly in the editor, covering a looping tone, an arm-then-trigger pause and resume, gain modulation, and positioning a mono source across the speakers.

The DocFX project, table of contents, and template live under `docs/` and build with `docs/build.ps1`, which exports the embedded workflows to images before running `docfx`. A short repo `README.md` is added as the GitHub landing, with the rich guide living in the docs site.

`Bonsai.Mixer.csproj` moves to plural `TargetFrameworks` so the release artifacts carry the framework segment the image export globs for, otherwise the package operators render as unknown types.