### PR TITLE
Update CI workflow to the latest reference

### DIFF
--- a/.github/workflows/Bonsai.Mixer.yml
+++ b/.github/workflows/Bonsai.Mixer.yml
@@ -15,11 +15,15 @@ name: Bonsai.Mixer
 on:
   push:
     # This prevents tag pushes from triggering this workflow
-    branches: ['*']
+    branches: ['**']
   pull_request:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      publish-documentation:
+        description: "Publish documentation to GitHub Pages?"
+        default: "false"
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -58,20 +62,20 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       # ----------------------------------------------------------------------- Set up tools
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       # ----------------------------------------------------------------------- Configure build
       - name: Configure build
         id: configure-build
-        uses: bonsai-rx/configure-build@v1
+        uses: bonsai-rx/configure-build@v2
 
       # ----------------------------------------------------------------------- Build
       - name: Restore
@@ -96,7 +100,7 @@ jobs:
 
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Collect NuGet packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: matrix.collect-packages && steps.pack.outcome == 'success' && always()
         with:
           name: Packages
@@ -116,18 +120,23 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       # ----------------------------------------------------------------------- Set up tools
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       - name: Set up .NET tools
         run: dotnet tool restore
+
+      # ----------------------------------------------------------------------- Configure build
+      - name: Configure build
+        id: configure-build
+        uses: bonsai-rx/configure-build@v2
 
       # ----------------------------------------------------------------------- Restore
       - name: Restore
@@ -145,7 +154,7 @@ jobs:
 
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Collect documentation metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: steps.build-metadata.outcome == 'success' && always()
         with:
           name: DocumentationMetadata
@@ -153,7 +162,7 @@ jobs:
           path: artifacts/docs/api/
 
       - name: Collect documentation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: steps.build-documentation.outcome == 'success' && always()
         with:
           name: DocumentationWebsite
@@ -176,20 +185,20 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       # ----------------------------------------------------------------------- Download built packages
       - name: Download packages for rendering
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: artifacts/packages/
 
       # ----------------------------------------------------------------------- Set up Bonsai environments
       - name: Set up Bonsai environments
-        uses: bonsai-rx/setup-bonsai@v1
+        uses: bonsai-rx/setup-bonsai@v2
         with:
           environment-paths: '**/.bonsai/'
           inject-packages: artifacts/packages/*.nupkg
@@ -201,7 +210,7 @@ jobs:
 
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Collect images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: steps.render.outcome == 'success' && always()
         with:
           name: DocumentationWorkflowImages
@@ -229,13 +238,13 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Set up .NET
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       # ----------------------------------------------------------------------- Download built packages
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: artifacts/packages/
@@ -271,13 +280,13 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Set up .NET
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       # ----------------------------------------------------------------------- Download built packages
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: artifacts/packages/
@@ -314,6 +323,7 @@ jobs:
     if: |
       !cancelled() && !failure() && needs.build-documentation.result == 'success'
       && (github.event_name == 'release'
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-documentation == 'true')
         || (vars.CONTINUOUS_DOCUMENTATION && github.event_name != 'pull_request')
       )
     steps:
@@ -321,24 +331,23 @@ jobs:
       # It is intentional that we use two independent download steps here as it ensures that workflow images are permitted
       # to overwrite any conflicts in the docfx output but not the other way around.
       - name: Download documentation website
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: DocumentationWebsite
 
       - name: Download workflow images
         if: ${{needs.workflow-images.result == 'success'}}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: DocumentationWorkflowImages
 
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Upload final documentation website artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: '.'
 
-      # ----------------------------------------------------------------------- Publish to GitHub Pages (for forks)
-      - name: Publish to GitHub Pages (forks)
+      # ----------------------------------------------------------------------- Publish to GitHub Pages
+      - name: Publish to GitHub Pages
         id: publish
-        if: github.event_name == 'release' || github.event.repository.fork
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Syncs the CI workflow with the latest [bonsai-rx/prefect](https://github.com/bonsai-rx/prefect) reference. Beyond bumping the GitHub Actions and bonsai-rx action versions to their current majors, this adds a `workflow_dispatch` input that publishes the documentation site on demand, so the site can be regenerated without a release.